### PR TITLE
feat: add SCOOP Intelligence Atlas

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -45,6 +45,7 @@ def _load_route_module(module_name: str) -> _RouteModule:
 
 gdelt = _load_route_module("gdelt")
 wiki = _load_route_module("wiki")
+wiki_atlas = _load_route_module("wiki_atlas")
 
 router = APIRouter()
 router.include_router(general.router)
@@ -73,3 +74,4 @@ router.include_router(gdelt.router)
 router.include_router(comparison.router)
 router.include_router(blindspots.router)
 router.include_router(wiki.router)
+router.include_router(wiki_atlas.router)

--- a/backend/app/api/routes/wiki_atlas.py
+++ b/backend/app/api/routes/wiki_atlas.py
@@ -82,11 +82,10 @@ async def get_atlas_graph(
     neighbors: int = Query(0, ge=0, le=2),
     limit_nodes: int = Query(350, ge=1, le=600),
     limit_edges: int = Query(1500, ge=1, le=2500),
-    layout: Literal["clustered", "ownership", "geography", "radial"] = Query(
-        "clustered"
-    ),
+    layout: Literal["clustered", "ownership", "geography", "radial"] = Query("clustered"),
     include_evidence_preview: bool = Query(True),
 ) -> AtlasGraphResponse:
+    """Return a bounded graph for the requested Atlas filters."""
     filters = AtlasGraphFilters(
         q=q,
         entity_types=_validated_entity_types(entity_types),
@@ -107,6 +106,7 @@ async def get_atlas_graph(
 
 @router.get("/stats", response_model=AtlasStatsResponse)
 async def get_atlas_stats(db: AsyncSession = Depends(get_db)) -> AtlasStatsResponse:
+    """Return graph coverage and indexing status."""
     return await build_atlas_stats(db)
 
 
@@ -116,6 +116,7 @@ async def search_atlas_entities(
     limit: int = Query(8, ge=1, le=20),
     db: AsyncSession = Depends(get_db),
 ) -> AtlasSearchResponse:
+    """Search Atlas entities and group matches by entity type."""
     return await search_atlas(db, q, limit=limit)
 
 
@@ -124,6 +125,7 @@ async def get_atlas_entity_record(
     entity_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> AtlasEntityRecord:
+    """Return one Atlas entity with evidence and connections."""
     record = await get_atlas_entity(db, entity_id)
     if record is None:
         raise HTTPException(status_code=404, detail="Atlas entity not found")
@@ -138,6 +140,7 @@ async def get_atlas_entity_connections(
     entity_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> list[AtlasConnectionRecord]:
+    """Return the relationships connected to one Atlas entity."""
     record = await get_atlas_entity(db, entity_id)
     if record is None:
         raise HTTPException(status_code=404, detail="Atlas entity not found")
@@ -162,6 +165,7 @@ async def get_atlas_index(
     cursor: str | None = Query(None, max_length=100),
     limit: int = Query(60, ge=1, le=100),
 ) -> AtlasIndexResponse:
+    """Return one filtered and sorted page of the Atlas entity index."""
     return await list_atlas_index(
         db,
         entity_types=_validated_entity_types(entity_types),
@@ -180,6 +184,7 @@ async def export_atlas(
     request: AtlasExportRequest,
     db: AsyncSession = Depends(get_db),
 ) -> Response:
+    """Export the requested Atlas graph as versioned JSON or CSV."""
     filename, content_type, content = await build_atlas_export(db, request)
     return Response(
         content=content,

--- a/backend/app/api/routes/wiki_atlas.py
+++ b/backend/app/api/routes/wiki_atlas.py
@@ -1,0 +1,188 @@
+"""SCOOP Intelligence Atlas API routes."""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.atlas import (
+    AtlasConnectionRecord,
+    AtlasEntityRecord,
+    AtlasEntityType,
+    AtlasExportRequest,
+    AtlasGraphFilters,
+    AtlasGraphResponse,
+    AtlasIndexResponse,
+    AtlasRelationType,
+    AtlasSearchResponse,
+    AtlasStatsResponse,
+)
+from app.services.atlas_entity import get_atlas_entity, list_atlas_index, search_atlas
+from app.services.atlas_export import build_atlas_export
+from app.services.atlas_graph import build_atlas_graph, build_atlas_stats
+
+router = APIRouter(prefix="/api/wiki/atlas", tags=["wiki-atlas"])
+
+_ENTITY_TYPES = {"source", "organization", "reporter"}
+_RELATION_TYPES = {
+    "ownership",
+    "owned_by",
+    "parent_org",
+    "part_of",
+    "publishes",
+    "employed_by",
+    "current_outlet",
+    "coauthor",
+    "shared_outlet",
+}
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _validated_entity_types(value: str | None) -> list[AtlasEntityType]:
+    values = _split_csv(value)
+    unsupported = sorted(set(values) - _ENTITY_TYPES)
+    if unsupported:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported entity types: {', '.join(unsupported)}",
+        )
+    return cast(list[AtlasEntityType], values)
+
+
+def _validated_relation_types(value: str | None) -> list[AtlasRelationType]:
+    values = _split_csv(value)
+    unsupported = sorted(set(values) - _RELATION_TYPES)
+    if unsupported:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported relation types: {', '.join(unsupported)}",
+        )
+    return cast(list[AtlasRelationType], values)
+
+
+@router.get("/graph", response_model=AtlasGraphResponse)
+async def get_atlas_graph(
+    db: AsyncSession = Depends(get_db),
+    q: str | None = Query(None, max_length=200),
+    entity_types: str | None = Query(None),
+    relation_types: str | None = Query(None),
+    country: str | None = Query(None),
+    funding: str | None = Query(None),
+    bias: str | None = Query(None),
+    min_confidence: float = Query(0.0, ge=0.0, le=1.0),
+    selected: str | None = Query(None, max_length=160),
+    neighbors: int = Query(0, ge=0, le=2),
+    limit_nodes: int = Query(350, ge=1, le=600),
+    limit_edges: int = Query(1500, ge=1, le=2500),
+    layout: Literal["clustered", "ownership", "geography", "radial"] = Query(
+        "clustered"
+    ),
+    include_evidence_preview: bool = Query(True),
+) -> AtlasGraphResponse:
+    filters = AtlasGraphFilters(
+        q=q,
+        entity_types=_validated_entity_types(entity_types),
+        relation_types=_validated_relation_types(relation_types),
+        country=_split_csv(country),
+        funding=_split_csv(funding),
+        bias=_split_csv(bias),
+        min_confidence=min_confidence,
+        selected=selected,
+        neighbors=neighbors,
+        limit_nodes=limit_nodes,
+        limit_edges=limit_edges,
+        layout=layout,
+        include_evidence_preview=include_evidence_preview,
+    )
+    return await build_atlas_graph(db, filters)
+
+
+@router.get("/stats", response_model=AtlasStatsResponse)
+async def get_atlas_stats(db: AsyncSession = Depends(get_db)) -> AtlasStatsResponse:
+    return await build_atlas_stats(db)
+
+
+@router.get("/search", response_model=AtlasSearchResponse)
+async def search_atlas_entities(
+    q: str = Query(..., min_length=1, max_length=200),
+    limit: int = Query(8, ge=1, le=20),
+    db: AsyncSession = Depends(get_db),
+) -> AtlasSearchResponse:
+    return await search_atlas(db, q, limit=limit)
+
+
+@router.get("/entities/{entity_id}", response_model=AtlasEntityRecord)
+async def get_atlas_entity_record(
+    entity_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> AtlasEntityRecord:
+    record = await get_atlas_entity(db, entity_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Atlas entity not found")
+    return record
+
+
+@router.get(
+    "/entities/{entity_id}/connections",
+    response_model=list[AtlasConnectionRecord],
+)
+async def get_atlas_entity_connections(
+    entity_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> list[AtlasConnectionRecord]:
+    record = await get_atlas_entity(db, entity_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Atlas entity not found")
+    return record.connections
+
+
+@router.get("/index", response_model=AtlasIndexResponse)
+async def get_atlas_index(
+    db: AsyncSession = Depends(get_db),
+    entity_types: str | None = Query(None),
+    q: str | None = Query(None, max_length=200),
+    country: str | None = Query(None),
+    funding: str | None = Query(None),
+    bias: str | None = Query(None),
+    sort: Literal[
+        "name",
+        "most_connected",
+        "most_articles",
+        "recently_indexed",
+        "lowest_confidence",
+    ] = Query("name"),
+    cursor: str | None = Query(None, max_length=100),
+    limit: int = Query(60, ge=1, le=100),
+) -> AtlasIndexResponse:
+    return await list_atlas_index(
+        db,
+        entity_types=_validated_entity_types(entity_types),
+        query=q,
+        country=_split_csv(country),
+        funding=_split_csv(funding),
+        bias=_split_csv(bias),
+        sort=sort,
+        cursor=cursor,
+        limit=limit,
+    )
+
+
+@router.post("/export")
+async def export_atlas(
+    request: AtlasExportRequest,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    filename, content_type, content = await build_atlas_export(db, request)
+    return Response(
+        content=content,
+        media_type=content_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/app/models/atlas.py
+++ b/backend/app/models/atlas.py
@@ -84,17 +84,22 @@ class AtlasEdge(BaseModel):
 
 
 class AtlasCoverageMetric(BaseModel):
+    """A numerator and denominator for an Atlas coverage measure."""
+
     numerator: int = 0
     denominator: int = 0
 
     @property
     def percentage(self) -> float:
+        """Return the coverage percentage, or zero for an empty population."""
         if self.denominator <= 0:
             return 0.0
         return round((self.numerator / self.denominator) * 100, 1)
 
 
 class AtlasGraphStats(BaseModel):
+    """Aggregate counts for the full and currently visible Atlas graph."""
+
     total_sources: int = 0
     total_organizations: int = 0
     total_reporters: int = 0
@@ -109,6 +114,8 @@ class AtlasGraphStats(BaseModel):
 
 
 class AtlasGraphFilters(BaseModel):
+    """Validated filters and bounds for an Atlas graph request."""
+
     q: str | None = None
     entity_types: list[AtlasEntityType] = Field(default_factory=list)
     relation_types: list[AtlasRelationType] = Field(default_factory=list)
@@ -125,6 +132,8 @@ class AtlasGraphFilters(BaseModel):
 
 
 class AtlasGraphResponse(BaseModel):
+    """A bounded Atlas graph projection and its request metadata."""
+
     graph_version: str
     generated_at: datetime
     nodes: list[AtlasNode] = Field(default_factory=list)
@@ -137,6 +146,8 @@ class AtlasGraphResponse(BaseModel):
 
 
 class AtlasStatsResponse(BaseModel):
+    """Atlas graph and indexing statistics."""
+
     graph_version: str
     generated_at: datetime
     stats: AtlasGraphStats
@@ -148,6 +159,8 @@ class AtlasStatsResponse(BaseModel):
 
 
 class AtlasSearchItem(BaseModel):
+    """A compact entity search result."""
+
     id: str
     entity_type: AtlasEntityType
     label: str
@@ -158,6 +171,8 @@ class AtlasSearchItem(BaseModel):
 
 
 class AtlasSearchResponse(BaseModel):
+    """Entity search results grouped by type."""
+
     query: str
     sources: list[AtlasSearchItem] = Field(default_factory=list)
     organizations: list[AtlasSearchItem] = Field(default_factory=list)
@@ -165,11 +180,15 @@ class AtlasSearchResponse(BaseModel):
 
 
 class AtlasConnectionRecord(BaseModel):
+    """A relationship paired with the entity on its other end."""
+
     edge: AtlasEdge
     entity: AtlasNode
 
 
 class AtlasEntityRecord(BaseModel):
+    """Detailed evidence and connections for one Atlas entity."""
+
     id: str
     entity_type: AtlasEntityType
     label: str
@@ -185,6 +204,8 @@ class AtlasEntityRecord(BaseModel):
 
 
 class AtlasIndexResponse(BaseModel):
+    """One cursor-based page from the Atlas entity index."""
+
     items: list[AtlasNode] = Field(default_factory=list)
     total: int = 0
     next_cursor: str | None = None
@@ -192,6 +213,8 @@ class AtlasIndexResponse(BaseModel):
 
 
 class AtlasExportRequest(BaseModel):
+    """Requested Atlas export format, scope, and optional layout data."""
+
     filters: AtlasGraphFilters = Field(default_factory=AtlasGraphFilters)
     selected_entity: str | None = None
     format: Literal["json", "csv_nodes", "csv_relationships", "csv_evidence"] = "json"

--- a/backend/app/models/atlas.py
+++ b/backend/app/models/atlas.py
@@ -1,0 +1,199 @@
+"""Typed contracts for the SCOOP Intelligence Atlas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+AtlasEntityType = Literal["source", "organization", "reporter"]
+AtlasRelationType = Literal[
+    "ownership",
+    "owned_by",
+    "parent_org",
+    "part_of",
+    "publishes",
+    "employed_by",
+    "current_outlet",
+    "coauthor",
+    "shared_outlet",
+]
+AtlasConfidenceTier = Literal[
+    "verified",
+    "strong",
+    "likely",
+    "unresolved",
+    "conflicting",
+    "stale",
+]
+
+
+class AtlasEvidenceRef(BaseModel):
+    """Small evidence record safe to include in graph responses."""
+
+    id: str
+    source_type: str
+    source_name: str | None = None
+    source_url: str | None = None
+    retrieved_at: datetime | None = None
+    excerpt: str | None = None
+
+
+class AtlasNode(BaseModel):
+    """A stable Atlas entity node."""
+
+    id: str
+    entity_type: AtlasEntityType
+    label: str
+    subtitle: str | None = None
+    country_code: str | None = None
+    funding_type: str | None = None
+    bias_rating: str | None = None
+    factual_reporting: str | None = None
+    credibility_score: float | None = None
+    article_count: int = 0
+    connection_count: int = 0
+    ownership_connection_count: int = 0
+    status: str | None = None
+    confidence_tier: AtlasConfidenceTier | None = None
+    profile_path: str | None = None
+    updated_at: datetime | None = None
+    flags: list[str] = Field(default_factory=list)
+
+
+class AtlasEdge(BaseModel):
+    """A typed, evidence-aware Atlas relationship."""
+
+    id: str
+    source_id: str
+    target_id: str
+    relation_type: AtlasRelationType
+    direction: Literal["directed", "undirected"] = "directed"
+    weight: float = 1.0
+    ownership_percentage: float | None = None
+    confidence: float | None = None
+    confidence_tier: AtlasConfidenceTier | None = None
+    evidence_count: int = 0
+    evidence_preview: list[AtlasEvidenceRef] = Field(default_factory=list)
+    valid_from: datetime | None = None
+    valid_to: datetime | None = None
+    last_verified_at: datetime | None = None
+    is_inferred: bool = False
+    raw_relation_type: str | None = None
+
+
+class AtlasCoverageMetric(BaseModel):
+    numerator: int = 0
+    denominator: int = 0
+
+    @property
+    def percentage(self) -> float:
+        if self.denominator <= 0:
+            return 0.0
+        return round((self.numerator / self.denominator) * 100, 1)
+
+
+class AtlasGraphStats(BaseModel):
+    total_sources: int = 0
+    total_organizations: int = 0
+    total_reporters: int = 0
+    visible_sources: int = 0
+    visible_organizations: int = 0
+    visible_reporters: int = 0
+    visible_relationships: int = 0
+    current_relationships: int = 0
+    ownership_coverage: AtlasCoverageMetric = Field(default_factory=AtlasCoverageMetric)
+    evidence_coverage: AtlasCoverageMetric = Field(default_factory=AtlasCoverageMetric)
+    unresolved_source_links: int = 0
+
+
+class AtlasGraphFilters(BaseModel):
+    q: str | None = None
+    entity_types: list[AtlasEntityType] = Field(default_factory=list)
+    relation_types: list[AtlasRelationType] = Field(default_factory=list)
+    country: list[str] = Field(default_factory=list)
+    funding: list[str] = Field(default_factory=list)
+    bias: list[str] = Field(default_factory=list)
+    min_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    selected: str | None = None
+    neighbors: int = Field(default=0, ge=0, le=2)
+    layout: Literal["clustered", "ownership", "geography", "radial"] = "clustered"
+    limit_nodes: int = Field(default=350, ge=1, le=600)
+    limit_edges: int = Field(default=1500, ge=1, le=2500)
+    include_evidence_preview: bool = True
+
+
+class AtlasGraphResponse(BaseModel):
+    graph_version: str
+    generated_at: datetime
+    nodes: list[AtlasNode] = Field(default_factory=list)
+    edges: list[AtlasEdge] = Field(default_factory=list)
+    stats: AtlasGraphStats
+    applied_filters: AtlasGraphFilters
+    truncated: bool = False
+    truncation_reason: str | None = None
+    next_expansion_token: str | None = None
+
+
+class AtlasStatsResponse(BaseModel):
+    graph_version: str
+    generated_at: datetime
+    stats: AtlasGraphStats
+    by_entity_type: dict[str, int] = Field(default_factory=dict)
+    by_relation_type: dict[str, int] = Field(default_factory=dict)
+    by_index_status: dict[str, int] = Field(default_factory=dict)
+    last_indexed_at: datetime | None = None
+    indexing_active: bool = False
+
+
+class AtlasSearchItem(BaseModel):
+    id: str
+    entity_type: AtlasEntityType
+    label: str
+    subtitle: str | None = None
+    country_code: str | None = None
+    confidence_tier: AtlasConfidenceTier | None = None
+    profile_path: str | None = None
+
+
+class AtlasSearchResponse(BaseModel):
+    query: str
+    sources: list[AtlasSearchItem] = Field(default_factory=list)
+    organizations: list[AtlasSearchItem] = Field(default_factory=list)
+    reporters: list[AtlasSearchItem] = Field(default_factory=list)
+
+
+class AtlasConnectionRecord(BaseModel):
+    edge: AtlasEdge
+    entity: AtlasNode
+
+
+class AtlasEntityRecord(BaseModel):
+    id: str
+    entity_type: AtlasEntityType
+    label: str
+    subtitle: str | None = None
+    country_code: str | None = None
+    status: str | None = None
+    confidence_tier: AtlasConfidenceTier | None = None
+    last_verified_at: datetime | None = None
+    profile_path: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[AtlasEvidenceRef] = Field(default_factory=list)
+    connections: list[AtlasConnectionRecord] = Field(default_factory=list)
+
+
+class AtlasIndexResponse(BaseModel):
+    items: list[AtlasNode] = Field(default_factory=list)
+    total: int = 0
+    next_cursor: str | None = None
+    facets: dict[str, dict[str, int]] = Field(default_factory=dict)
+
+
+class AtlasExportRequest(BaseModel):
+    filters: AtlasGraphFilters = Field(default_factory=AtlasGraphFilters)
+    selected_entity: str | None = None
+    format: Literal["json", "csv_nodes", "csv_relationships", "csv_evidence"] = "json"
+    include_evidence: bool = True
+    visible_layout_positions: dict[str, dict[str, float]] | None = None

--- a/backend/app/services/atlas_entity.py
+++ b/backend/app/services/atlas_entity.py
@@ -21,6 +21,7 @@ from app.database import (
 from app.models.atlas import (
     AtlasConnectionRecord,
     AtlasEntityRecord,
+    AtlasEntityType,
     AtlasGraphFilters,
     AtlasIndexResponse,
     AtlasNode,
@@ -35,7 +36,7 @@ def _catalog_sources() -> dict[str, dict[str, Any]]:
     unique: dict[str, dict[str, Any]] = {}
     for raw_name, raw_config in get_rss_sources().items():
         name = raw_name.split(" - ")[0].strip()
-        unique.setdefault(name, cast(dict[str, Any], raw_config))
+        unique.setdefault(name, raw_config)
     return unique
 
 
@@ -43,20 +44,14 @@ def _decode_cursor(cursor: str | None) -> int:
     if not cursor:
         return 0
     try:
-        decoded = base64.urlsafe_b64decode(cursor.encode("ascii") + b"===").decode(
-            "ascii"
-        )
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii") + b"===").decode("ascii")
         return max(int(decoded), 0)
     except (ValueError, UnicodeDecodeError):
         return 0
 
 
 def _encode_cursor(offset: int) -> str:
-    return (
-        base64.urlsafe_b64encode(str(offset).encode("ascii"))
-        .decode("ascii")
-        .rstrip("=")
-    )
+    return base64.urlsafe_b64encode(str(offset).encode("ascii")).decode("ascii").rstrip("=")
 
 
 def _source_name_for_id(entity_id: str) -> str | None:
@@ -66,9 +61,8 @@ def _source_name_for_id(entity_id: str) -> str | None:
     return None
 
 
-async def search_atlas(
-    db: AsyncSession, query: str, limit: int = 8
-) -> AtlasSearchResponse:
+async def search_atlas(db: AsyncSession, query: str, limit: int = 8) -> AtlasSearchResponse:
+    """Search the bounded Atlas projection for grouped entity matches."""
     normalized_query = normalize_entity_label(query)
     graph = await build_atlas_graph(
         db,
@@ -130,9 +124,8 @@ async def search_atlas(
     )
 
 
-async def get_atlas_entity(
-    db: AsyncSession, entity_id: str
-) -> AtlasEntityRecord | None:
+async def get_atlas_entity(db: AsyncSession, entity_id: str) -> AtlasEntityRecord | None:
+    """Load one Atlas entity with its details, evidence, and connections."""
     graph = await build_atlas_graph(
         db,
         AtlasGraphFilters(
@@ -187,7 +180,7 @@ async def get_atlas_entity(
             .scalars()
             .all()
         )
-        claim_ids = [cast(int, claim.id) for claim in claims if claim.id is not None]
+        claim_ids = [claim.id for claim in claims if claim.id is not None]
         claim_evidence = []
         if claim_ids:
             claim_evidence = list(
@@ -204,32 +197,25 @@ async def get_atlas_entity(
         details = {
             "source_name": source_name,
             "website": config.get("site_url") or config.get("url"),
-            "source_type": cast(str | None, metadata.source_type if metadata else None),
+            "source_type": metadata.source_type if metadata else None,
             "category": config.get("category"),
             "funding_type": cast(
                 str | None,
-                (metadata.funding_type if metadata else None)
-                or config.get("funding_type"),
+                (metadata.funding_type if metadata else None) or config.get("funding_type"),
             ),
             "bias_rating": cast(
                 str | None,
-                (metadata.political_bias if metadata else None)
-                or config.get("bias_rating"),
+                (metadata.political_bias if metadata else None) or config.get("bias_rating"),
             ),
             "factual_reporting": cast(
                 str | None,
-                (metadata.factual_rating if metadata else None)
-                or config.get("factual_reporting"),
+                (metadata.factual_rating if metadata else None) or config.get("factual_reporting"),
             ),
             "credibility_score": cast(
                 float | None, metadata.credibility_score if metadata else None
             ),
-            "parent_company": cast(
-                str | None, metadata.parent_company if metadata else None
-            ),
-            "geographic_focus": cast(
-                list[str], metadata.geographic_focus if metadata else []
-            ),
+            "parent_company": metadata.parent_company if metadata else None,
+            "geographic_focus": cast(list[str], metadata.geographic_focus if metadata else []),
             "topic_focus": cast(list[str], metadata.topic_focus if metadata else []),
             "claims": [
                 {
@@ -246,11 +232,7 @@ async def get_atlas_entity(
         }
         if claim_evidence:
             last_verified_at = max(
-                (
-                    cast(datetime, row.retrieved_at)
-                    for row in claim_evidence
-                    if row.retrieved_at
-                ),
+                (row.retrieved_at for row in claim_evidence if row.retrieved_at),
                 default=None,
             )
     elif entity_id.startswith("organization:"):
@@ -278,7 +260,7 @@ async def get_atlas_entity(
             "research_sources": org.research_sources or [],
             "conflict_flags": org.conflict_flags or [],
         }
-        last_verified_at = cast(datetime | None, org.last_researched_at)
+        last_verified_at = org.last_researched_at
     elif entity_id.startswith("reporter:"):
         try:
             reporter_id = int(entity_id.split(":", 1)[1])
@@ -311,7 +293,7 @@ async def get_atlas_entity(
             "research_sources": reporter.research_sources or [],
             "match_explanation": reporter.match_explanation,
         }
-        last_verified_at = cast(datetime | None, reporter.last_researched_at)
+        last_verified_at = reporter.last_researched_at
 
     deduped_evidence = {item.id: item for item in evidence}
     return AtlasEntityRecord(
@@ -340,7 +322,7 @@ async def get_atlas_entity(
 async def list_atlas_index(
     db: AsyncSession,
     *,
-    entity_types: list[str],
+    entity_types: list[AtlasEntityType],
     query: str | None,
     country: list[str],
     funding: list[str],
@@ -349,10 +331,11 @@ async def list_atlas_index(
     cursor: str | None,
     limit: int,
 ) -> AtlasIndexResponse:
+    """Return a filtered, sorted, cursor-based entity index page."""
     graph = await build_atlas_graph(
         db,
         AtlasGraphFilters(
-            entity_types=cast(list[Any], entity_types),
+            entity_types=entity_types,
             q=query,
             country=country,
             funding=funding,
@@ -394,19 +377,13 @@ async def list_atlas_index(
     offset = _decode_cursor(cursor)
     page = items[offset : offset + limit]
     next_offset = offset + len(page)
-    facets = {
+    facets: dict[str, dict[str, int]] = {
         "entity_type": dict(Counter(node.entity_type for node in items)),
-        "country": dict(
-            Counter(node.country_code for node in items if node.country_code)
-        ),
-        "funding": dict(
-            Counter(node.funding_type for node in items if node.funding_type)
-        ),
+        "country": dict(Counter(node.country_code for node in items if node.country_code)),
+        "funding": dict(Counter(node.funding_type for node in items if node.funding_type)),
         "bias": dict(Counter(node.bias_rating for node in items if node.bias_rating)),
         "status": dict(Counter(node.status for node in items if node.status)),
-        "confidence": dict(
-            Counter(node.confidence_tier for node in items if node.confidence_tier)
-        ),
+        "confidence": dict(Counter(node.confidence_tier for node in items if node.confidence_tier)),
     }
     return AtlasIndexResponse(
         items=page,

--- a/backend/app/services/atlas_entity.py
+++ b/backend/app/services/atlas_entity.py
@@ -1,0 +1,416 @@
+"""Entity, search, and paginated index services for the Intelligence Atlas."""
+
+from __future__ import annotations
+
+import base64
+from collections import Counter
+from datetime import datetime
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.data.rss_sources import get_rss_sources
+from app.database import (
+    Organization,
+    Reporter,
+    SourceClaim,
+    SourceClaimEvidence,
+    SourceMetadata,
+)
+from app.models.atlas import (
+    AtlasConnectionRecord,
+    AtlasEntityRecord,
+    AtlasGraphFilters,
+    AtlasIndexResponse,
+    AtlasNode,
+    AtlasSearchItem,
+    AtlasSearchResponse,
+)
+from app.services.atlas_graph import build_atlas_graph
+from app.services.atlas_graph_helpers import normalize_entity_label, stable_source_id
+
+
+def _catalog_sources() -> dict[str, dict[str, Any]]:
+    unique: dict[str, dict[str, Any]] = {}
+    for raw_name, raw_config in get_rss_sources().items():
+        name = raw_name.split(" - ")[0].strip()
+        unique.setdefault(name, cast(dict[str, Any], raw_config))
+    return unique
+
+
+def _decode_cursor(cursor: str | None) -> int:
+    if not cursor:
+        return 0
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii") + b"===").decode(
+            "ascii"
+        )
+        return max(int(decoded), 0)
+    except (ValueError, UnicodeDecodeError):
+        return 0
+
+
+def _encode_cursor(offset: int) -> str:
+    return (
+        base64.urlsafe_b64encode(str(offset).encode("ascii"))
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+
+def _source_name_for_id(entity_id: str) -> str | None:
+    for source_name in _catalog_sources():
+        if stable_source_id(source_name) == entity_id:
+            return source_name
+    return None
+
+
+async def search_atlas(
+    db: AsyncSession, query: str, limit: int = 8
+) -> AtlasSearchResponse:
+    normalized_query = normalize_entity_label(query)
+    graph = await build_atlas_graph(
+        db,
+        AtlasGraphFilters(
+            entity_types=["source", "organization", "reporter"],
+            limit_nodes=600,
+            limit_edges=2500,
+            include_evidence_preview=False,
+        ),
+    )
+
+    def score(node: AtlasNode) -> tuple[int, int, str]:
+        normalized_label = normalize_entity_label(node.label)
+        if normalized_label == normalized_query:
+            match_rank = 0
+        elif normalized_label.startswith(normalized_query):
+            match_rank = 1
+        elif normalized_query in normalized_label:
+            match_rank = 2
+        else:
+            metadata = normalize_entity_label(
+                " ".join(
+                    value
+                    for value in (node.subtitle, node.country_code, node.funding_type)
+                    if value
+                )
+            )
+            match_rank = 3 if normalized_query in metadata else 9
+        return (match_rank, -node.connection_count, node.label.casefold())
+
+    matched = [node for node in graph.nodes if score(node)[0] < 9]
+    matched.sort(key=score)
+
+    grouped: dict[str, list[AtlasSearchItem]] = {
+        "source": [],
+        "organization": [],
+        "reporter": [],
+    }
+    for node in matched:
+        bucket = grouped[node.entity_type]
+        if len(bucket) >= limit:
+            continue
+        bucket.append(
+            AtlasSearchItem(
+                id=node.id,
+                entity_type=node.entity_type,
+                label=node.label,
+                subtitle=node.subtitle,
+                country_code=node.country_code,
+                confidence_tier=node.confidence_tier,
+                profile_path=node.profile_path,
+            )
+        )
+    return AtlasSearchResponse(
+        query=query,
+        sources=grouped["source"],
+        organizations=grouped["organization"],
+        reporters=grouped["reporter"],
+    )
+
+
+async def get_atlas_entity(
+    db: AsyncSession, entity_id: str
+) -> AtlasEntityRecord | None:
+    graph = await build_atlas_graph(
+        db,
+        AtlasGraphFilters(
+            entity_types=["source", "organization", "reporter"],
+            selected=entity_id,
+            neighbors=1,
+            limit_nodes=350,
+            limit_edges=1500,
+            include_evidence_preview=True,
+        ),
+    )
+    node = next((item for item in graph.nodes if item.id == entity_id), None)
+    if node is None:
+        return None
+
+    node_by_id = {item.id: item for item in graph.nodes}
+    connections: list[AtlasConnectionRecord] = []
+    evidence = []
+    for edge in graph.edges:
+        if edge.source_id == entity_id:
+            related = node_by_id.get(edge.target_id)
+        elif edge.target_id == entity_id:
+            related = node_by_id.get(edge.source_id)
+        else:
+            continue
+        if related is None:
+            continue
+        connections.append(AtlasConnectionRecord(edge=edge, entity=related))
+        evidence.extend(edge.evidence_preview)
+
+    details: dict[str, Any] = {}
+    last_verified_at: datetime | None = None
+    if entity_id.startswith("source:"):
+        source_name = _source_name_for_id(entity_id)
+        if source_name is None:
+            return None
+        config = _catalog_sources().get(source_name, {})
+        metadata = (
+            await db.execute(
+                select(SourceMetadata).where(SourceMetadata.source_name == source_name)
+            )
+        ).scalar_one_or_none()
+        claims = list(
+            (
+                await db.execute(
+                    select(SourceClaim).where(
+                        SourceClaim.source_name == source_name,
+                        SourceClaim.is_current.is_(True),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        claim_ids = [cast(int, claim.id) for claim in claims if claim.id is not None]
+        claim_evidence = []
+        if claim_ids:
+            claim_evidence = list(
+                (
+                    await db.execute(
+                        select(SourceClaimEvidence).where(
+                            SourceClaimEvidence.claim_id.in_(claim_ids)
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        details = {
+            "source_name": source_name,
+            "website": config.get("site_url") or config.get("url"),
+            "source_type": cast(str | None, metadata.source_type if metadata else None),
+            "category": config.get("category"),
+            "funding_type": cast(
+                str | None,
+                (metadata.funding_type if metadata else None)
+                or config.get("funding_type"),
+            ),
+            "bias_rating": cast(
+                str | None,
+                (metadata.political_bias if metadata else None)
+                or config.get("bias_rating"),
+            ),
+            "factual_reporting": cast(
+                str | None,
+                (metadata.factual_rating if metadata else None)
+                or config.get("factual_reporting"),
+            ),
+            "credibility_score": cast(
+                float | None, metadata.credibility_score if metadata else None
+            ),
+            "parent_company": cast(
+                str | None, metadata.parent_company if metadata else None
+            ),
+            "geographic_focus": cast(
+                list[str], metadata.geographic_focus if metadata else []
+            ),
+            "topic_focus": cast(list[str], metadata.topic_focus if metadata else []),
+            "claims": [
+                {
+                    "id": claim.id,
+                    "type": claim.claim_type,
+                    "value": claim.claim_value,
+                    "kind": claim.claim_kind,
+                    "confidence": claim.confidence,
+                    "valid_from": claim.valid_from,
+                    "valid_to": claim.valid_to,
+                }
+                for claim in claims
+            ],
+        }
+        if claim_evidence:
+            last_verified_at = max(
+                (
+                    cast(datetime, row.retrieved_at)
+                    for row in claim_evidence
+                    if row.retrieved_at
+                ),
+                default=None,
+            )
+    elif entity_id.startswith("organization:"):
+        try:
+            org_id = int(entity_id.split(":", 1)[1])
+        except ValueError:
+            return None
+        org = await db.get(Organization, org_id)
+        if org is None:
+            return None
+        details = {
+            "organization_type": org.org_type,
+            "legal_name": org.name,
+            "funding_type": org.funding_type,
+            "funding_sources": org.funding_sources or [],
+            "major_advertisers": org.major_advertisers or [],
+            "annual_revenue": org.annual_revenue,
+            "parent_organization_id": org.parent_org_id,
+            "ownership_percentage": org.ownership_percentage,
+            "owned_by": org.owned_by or [],
+            "parent_organizations": org.parent_orgs or [],
+            "part_of": org.part_of or [],
+            "website": org.website or org.official_website,
+            "wikipedia_url": org.wikipedia_url,
+            "research_sources": org.research_sources or [],
+            "conflict_flags": org.conflict_flags or [],
+        }
+        last_verified_at = cast(datetime | None, org.last_researched_at)
+    elif entity_id.startswith("reporter:"):
+        try:
+            reporter_id = int(entity_id.split(":", 1)[1])
+        except ValueError:
+            return None
+        reporter = await db.get(Reporter, reporter_id)
+        if reporter is None:
+            return None
+        person_evidence = [
+            value
+            for value in (
+                reporter.author_page_url,
+                reporter.canonical_author_url,
+                reporter.wikipedia_url,
+                reporter.wikidata_url,
+            )
+            if value
+        ]
+        details = {
+            "canonical_name": reporter.canonical_name or reporter.name,
+            "match_status": reporter.match_status,
+            "person_level_evidence": person_evidence,
+            "career_history": reporter.career_history or [],
+            "institutional_affiliations": reporter.institutional_affiliations or [],
+            "topics": reporter.topics or [],
+            "education": reporter.education or [],
+            "article_count": reporter.article_count or 0,
+            "political_leaning": reporter.political_leaning,
+            "leaning_confidence": reporter.leaning_confidence,
+            "research_sources": reporter.research_sources or [],
+            "match_explanation": reporter.match_explanation,
+        }
+        last_verified_at = cast(datetime | None, reporter.last_researched_at)
+
+    deduped_evidence = {item.id: item for item in evidence}
+    return AtlasEntityRecord(
+        id=node.id,
+        entity_type=node.entity_type,
+        label=node.label,
+        subtitle=node.subtitle,
+        country_code=node.country_code,
+        status=node.status,
+        confidence_tier=node.confidence_tier,
+        last_verified_at=last_verified_at or node.updated_at,
+        profile_path=node.profile_path,
+        details=details,
+        evidence=list(deduped_evidence.values()),
+        connections=sorted(
+            connections,
+            key=lambda item: (
+                -(item.edge.confidence or 0),
+                -item.edge.evidence_count,
+                item.entity.label.casefold(),
+            ),
+        ),
+    )
+
+
+async def list_atlas_index(
+    db: AsyncSession,
+    *,
+    entity_types: list[str],
+    query: str | None,
+    country: list[str],
+    funding: list[str],
+    bias: list[str],
+    sort: str,
+    cursor: str | None,
+    limit: int,
+) -> AtlasIndexResponse:
+    graph = await build_atlas_graph(
+        db,
+        AtlasGraphFilters(
+            entity_types=cast(list[Any], entity_types),
+            q=query,
+            country=country,
+            funding=funding,
+            bias=bias,
+            limit_nodes=600,
+            limit_edges=2500,
+            include_evidence_preview=False,
+        ),
+    )
+    items = list(graph.nodes)
+    if sort == "most_connected":
+        items.sort(key=lambda node: (-node.connection_count, node.label.casefold()))
+    elif sort == "most_articles":
+        items.sort(key=lambda node: (-node.article_count, node.label.casefold()))
+    elif sort == "recently_indexed":
+        items.sort(
+            key=lambda node: (
+                -(node.updated_at.timestamp() if node.updated_at else 0),
+                node.label.casefold(),
+            )
+        )
+    elif sort == "lowest_confidence":
+        tier_order = {
+            "unresolved": 0,
+            "likely": 1,
+            "strong": 2,
+            "verified": 3,
+            None: -1,
+        }
+        items.sort(
+            key=lambda node: (
+                tier_order.get(node.confidence_tier, 0),
+                node.label.casefold(),
+            )
+        )
+    else:
+        items.sort(key=lambda node: node.label.casefold())
+
+    offset = _decode_cursor(cursor)
+    page = items[offset : offset + limit]
+    next_offset = offset + len(page)
+    facets = {
+        "entity_type": dict(Counter(node.entity_type for node in items)),
+        "country": dict(
+            Counter(node.country_code for node in items if node.country_code)
+        ),
+        "funding": dict(
+            Counter(node.funding_type for node in items if node.funding_type)
+        ),
+        "bias": dict(Counter(node.bias_rating for node in items if node.bias_rating)),
+        "status": dict(Counter(node.status for node in items if node.status)),
+        "confidence": dict(
+            Counter(node.confidence_tier for node in items if node.confidence_tier)
+        ),
+    }
+    return AtlasIndexResponse(
+        items=page,
+        total=len(items),
+        next_cursor=_encode_cursor(next_offset) if next_offset < len(items) else None,
+        facets=facets,
+    )

--- a/backend/app/services/atlas_export.py
+++ b/backend/app/services/atlas_export.py
@@ -15,6 +15,7 @@ from app.services.atlas_graph import build_atlas_graph
 async def build_atlas_export(
     db: AsyncSession, request: AtlasExportRequest
 ) -> tuple[str, str, bytes]:
+    """Build a stable JSON or CSV export for an Atlas investigation."""
     filters = request.filters.model_copy(
         update={
             "selected": request.selected_entity or request.filters.selected,
@@ -24,10 +25,10 @@ async def build_atlas_export(
     graph = await build_atlas_graph(db, filters)
 
     if request.format == "json":
-        evidence = {
-            evidence.id: evidence.model_dump(mode="json")
+        evidence_by_id = {
+            evidence_ref.id: evidence_ref.model_dump(mode="json")
             for edge in graph.edges
-            for evidence in edge.evidence_preview
+            for evidence_ref in edge.evidence_preview
         }
         payload: dict[str, Any] = {
             "schema_version": "1.0",
@@ -37,7 +38,7 @@ async def build_atlas_export(
             "selected_entity": request.selected_entity,
             "nodes": [node.model_dump(mode="json") for node in graph.nodes],
             "relationships": [edge.model_dump(mode="json") for edge in graph.edges],
-            "evidence": list(evidence.values()),
+            "evidence": list(evidence_by_id.values()),
             "layout_positions": request.visible_layout_positions or {},
             "truncated": graph.truncated,
             "truncation_reason": graph.truncation_reason,
@@ -116,9 +117,7 @@ async def build_atlas_export(
                     edge.confidence if edge.confidence is not None else "",
                     edge.confidence_tier or "",
                     edge.evidence_count,
-                    edge.ownership_percentage
-                    if edge.ownership_percentage is not None
-                    else "",
+                    edge.ownership_percentage if edge.ownership_percentage is not None else "",
                     edge.valid_from.isoformat() if edge.valid_from else "",
                     edge.valid_to.isoformat() if edge.valid_to else "",
                     edge.last_verified_at.isoformat() if edge.last_verified_at else "",
@@ -139,18 +138,16 @@ async def build_atlas_export(
             ]
         )
         for edge in graph.edges:
-            for evidence in edge.evidence_preview:
+            for evidence_ref in edge.evidence_preview:
                 writer.writerow(
                     [
-                        evidence.id,
+                        evidence_ref.id,
                         edge.id,
-                        evidence.source_type,
-                        evidence.source_name or "",
-                        evidence.source_url or "",
-                        evidence.retrieved_at.isoformat()
-                        if evidence.retrieved_at
-                        else "",
-                        evidence.excerpt or "",
+                        evidence_ref.source_type,
+                        evidence_ref.source_name or "",
+                        evidence_ref.source_url or "",
+                        evidence_ref.retrieved_at.isoformat() if evidence_ref.retrieved_at else "",
+                        evidence_ref.excerpt or "",
                     ]
                 )
         filename = "atlas-evidence.csv"

--- a/backend/app/services/atlas_export.py
+++ b/backend/app/services/atlas_export.py
@@ -1,0 +1,158 @@
+"""Stable JSON and CSV export builders for Atlas investigations."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.atlas import AtlasExportRequest
+from app.services.atlas_graph import build_atlas_graph
+
+
+async def build_atlas_export(
+    db: AsyncSession, request: AtlasExportRequest
+) -> tuple[str, str, bytes]:
+    filters = request.filters.model_copy(
+        update={
+            "selected": request.selected_entity or request.filters.selected,
+            "include_evidence_preview": request.include_evidence,
+        }
+    )
+    graph = await build_atlas_graph(db, filters)
+
+    if request.format == "json":
+        evidence = {
+            evidence.id: evidence.model_dump(mode="json")
+            for edge in graph.edges
+            for evidence in edge.evidence_preview
+        }
+        payload: dict[str, Any] = {
+            "schema_version": "1.0",
+            "generated_at": graph.generated_at.isoformat(),
+            "graph_version": graph.graph_version,
+            "filters": graph.applied_filters.model_dump(mode="json"),
+            "selected_entity": request.selected_entity,
+            "nodes": [node.model_dump(mode="json") for node in graph.nodes],
+            "relationships": [edge.model_dump(mode="json") for edge in graph.edges],
+            "evidence": list(evidence.values()),
+            "layout_positions": request.visible_layout_positions or {},
+            "truncated": graph.truncated,
+            "truncation_reason": graph.truncation_reason,
+        }
+        import json
+
+        return (
+            "atlas-investigation.json",
+            "application/json",
+            json.dumps(payload, indent=2, ensure_ascii=False).encode("utf-8"),
+        )
+
+    buffer = io.StringIO(newline="")
+    writer = csv.writer(buffer)
+    if request.format == "csv_nodes":
+        writer.writerow(
+            [
+                "id",
+                "entity_type",
+                "label",
+                "subtitle",
+                "country_code",
+                "funding_type",
+                "bias_rating",
+                "article_count",
+                "connection_count",
+                "status",
+                "confidence_tier",
+                "updated_at",
+            ]
+        )
+        for node in graph.nodes:
+            writer.writerow(
+                [
+                    node.id,
+                    node.entity_type,
+                    node.label,
+                    node.subtitle or "",
+                    node.country_code or "",
+                    node.funding_type or "",
+                    node.bias_rating or "",
+                    node.article_count,
+                    node.connection_count,
+                    node.status or "",
+                    node.confidence_tier or "",
+                    node.updated_at.isoformat() if node.updated_at else "",
+                ]
+            )
+        filename = "atlas-entities.csv"
+    elif request.format == "csv_relationships":
+        writer.writerow(
+            [
+                "id",
+                "source_id",
+                "target_id",
+                "relation_type",
+                "raw_relation_type",
+                "confidence",
+                "confidence_tier",
+                "evidence_count",
+                "ownership_percentage",
+                "valid_from",
+                "valid_to",
+                "last_verified_at",
+                "is_inferred",
+            ]
+        )
+        for edge in graph.edges:
+            writer.writerow(
+                [
+                    edge.id,
+                    edge.source_id,
+                    edge.target_id,
+                    edge.relation_type,
+                    edge.raw_relation_type or "",
+                    edge.confidence if edge.confidence is not None else "",
+                    edge.confidence_tier or "",
+                    edge.evidence_count,
+                    edge.ownership_percentage
+                    if edge.ownership_percentage is not None
+                    else "",
+                    edge.valid_from.isoformat() if edge.valid_from else "",
+                    edge.valid_to.isoformat() if edge.valid_to else "",
+                    edge.last_verified_at.isoformat() if edge.last_verified_at else "",
+                    edge.is_inferred,
+                ]
+            )
+        filename = "atlas-relationships.csv"
+    else:
+        writer.writerow(
+            [
+                "id",
+                "relationship_id",
+                "source_type",
+                "source_name",
+                "source_url",
+                "retrieved_at",
+                "excerpt",
+            ]
+        )
+        for edge in graph.edges:
+            for evidence in edge.evidence_preview:
+                writer.writerow(
+                    [
+                        evidence.id,
+                        edge.id,
+                        evidence.source_type,
+                        evidence.source_name or "",
+                        evidence.source_url or "",
+                        evidence.retrieved_at.isoformat()
+                        if evidence.retrieved_at
+                        else "",
+                        evidence.excerpt or "",
+                    ]
+                )
+        filename = "atlas-evidence.csv"
+
+    return filename, "text/csv; charset=utf-8", buffer.getvalue().encode("utf-8")

--- a/backend/app/services/atlas_graph.py
+++ b/backend/app/services/atlas_graph.py
@@ -1,0 +1,273 @@
+"""Bounded graph queries and statistics for the Intelligence Atlas."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter, defaultdict, deque
+from datetime import UTC, datetime
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import WikiIndexStatus
+from app.models.atlas import (
+    AtlasCoverageMetric,
+    AtlasEdge,
+    AtlasEntityType,
+    AtlasGraphFilters,
+    AtlasGraphResponse,
+    AtlasGraphStats,
+    AtlasNode,
+    AtlasRelationType,
+    AtlasStatsResponse,
+)
+from app.services.atlas_graph_helpers import (
+    _RELATION_GROUPS,
+    _edge_matches,
+    _node_matches,
+)
+from app.services.atlas_graph_projection import _load_graph_projection
+
+
+def _apply_neighborhood(
+    nodes: list[AtlasNode],
+    edges: list[AtlasEdge],
+    selected: str | None,
+    neighbors: int,
+) -> tuple[list[AtlasNode], list[AtlasEdge]]:
+    if not selected or neighbors <= 0:
+        return nodes, edges
+    node_ids = {node.id for node in nodes}
+    if selected not in node_ids:
+        return nodes, edges
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for edge in edges:
+        adjacency[edge.source_id].add(edge.target_id)
+        adjacency[edge.target_id].add(edge.source_id)
+    visible = {selected}
+    queue: deque[tuple[str, int]] = deque([(selected, 0)])
+    while queue:
+        node_id, depth = queue.popleft()
+        if depth >= neighbors:
+            continue
+        for related in adjacency.get(node_id, set()):
+            if related in visible:
+                continue
+            visible.add(related)
+            queue.append((related, depth + 1))
+    return (
+        [node for node in nodes if node.id in visible],
+        [
+            edge
+            for edge in edges
+            if edge.source_id in visible and edge.target_id in visible
+        ],
+    )
+
+
+def _rank_nodes(
+    nodes: list[AtlasNode], edges: list[AtlasEdge], selected: str | None
+) -> list[AtlasNode]:
+    degree = Counter[str]()
+    ownership_degree = Counter[str]()
+    for edge in edges:
+        degree[edge.source_id] += 1
+        degree[edge.target_id] += 1
+        if edge.relation_type in {"ownership", "owned_by", "parent_org"}:
+            ownership_degree[edge.source_id] += 1
+            ownership_degree[edge.target_id] += 1
+    ranked: list[AtlasNode] = []
+    for node in nodes:
+        ranked.append(
+            node.model_copy(
+                update={
+                    "connection_count": degree[node.id],
+                    "ownership_connection_count": ownership_degree[node.id],
+                }
+            )
+        )
+    type_priority: dict[AtlasEntityType, int] = {
+        "organization": 0,
+        "source": 1,
+        "reporter": 2,
+    }
+    ranked.sort(
+        key=lambda node: (
+            0 if node.id == selected else 1,
+            type_priority[node.entity_type],
+            -node.connection_count,
+            -node.article_count,
+            node.label.casefold(),
+        )
+    )
+    return ranked
+
+
+def _graph_version(nodes: list[AtlasNode], edges: list[AtlasEdge]) -> str:
+    payload = {
+        "nodes": sorted(
+            (node.id, node.updated_at.isoformat() if node.updated_at else "")
+            for node in nodes
+        ),
+        "edges": sorted(
+            (
+                edge.id,
+                edge.last_verified_at.isoformat() if edge.last_verified_at else "",
+            )
+            for edge in edges
+        ),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return digest[:20]
+
+
+async def build_atlas_graph(
+    db: AsyncSession, filters: AtlasGraphFilters
+) -> AtlasGraphResponse:
+    generated_at = datetime.now(UTC)
+    (
+        all_nodes,
+        all_edges,
+        unresolved,
+        _index_counts,
+        _last_indexed,
+        _indexing,
+    ) = await _load_graph_projection(db, filters)
+
+    # A committed selection is a neighborhood lookup, not a label-only search.
+    # Preserve q in the response contract/URL while allowing connected entities
+    # that do not repeat the query text to remain visible.
+    node_match_filters = (
+        filters.model_copy(update={"q": None}) if filters.selected else filters
+    )
+    node_filtered = [
+        node for node in all_nodes if _node_matches(node, node_match_filters)
+    ]
+    allowed_node_ids = {node.id for node in node_filtered}
+    edge_filtered = [
+        edge
+        for edge in all_edges
+        if _edge_matches(edge, filters)
+        and edge.source_id in allowed_node_ids
+        and edge.target_id in allowed_node_ids
+    ]
+
+    node_filtered, edge_filtered = _apply_neighborhood(
+        node_filtered,
+        edge_filtered,
+        filters.selected,
+        min(max(filters.neighbors, 0), 2),
+    )
+    ranked_nodes = _rank_nodes(node_filtered, edge_filtered, filters.selected)
+
+    truncated = False
+    reasons: list[str] = []
+    if len(ranked_nodes) > filters.limit_nodes:
+        truncated = True
+        reasons.append("node_limit")
+        ranked_nodes = ranked_nodes[: filters.limit_nodes]
+    visible_ids = {node.id for node in ranked_nodes}
+    edge_filtered = [
+        edge
+        for edge in edge_filtered
+        if edge.source_id in visible_ids and edge.target_id in visible_ids
+    ]
+    if len(edge_filtered) > filters.limit_edges:
+        truncated = True
+        reasons.append("edge_limit")
+        edge_filtered = sorted(
+            edge_filtered,
+            key=lambda edge: (-(edge.confidence or 0.0), -edge.evidence_count, edge.id),
+        )[: filters.limit_edges]
+
+    evidence_edges = sum(1 for edge in edge_filtered if edge.evidence_count > 0)
+    ownership_edges = [
+        edge
+        for edge in all_edges
+        if edge.relation_type in {"ownership", "owned_by", "parent_org"}
+    ]
+    source_nodes = [node for node in all_nodes if node.entity_type == "source"]
+    sources_with_owner = {
+        edge.target_id
+        for edge in ownership_edges
+        if edge.target_id.startswith("source:") and edge.valid_to is None
+    }
+
+    stats = AtlasGraphStats(
+        total_sources=len(source_nodes),
+        total_organizations=sum(
+            node.entity_type == "organization" for node in all_nodes
+        ),
+        total_reporters=sum(node.entity_type == "reporter" for node in all_nodes),
+        visible_sources=sum(node.entity_type == "source" for node in ranked_nodes),
+        visible_organizations=sum(
+            node.entity_type == "organization" for node in ranked_nodes
+        ),
+        visible_reporters=sum(node.entity_type == "reporter" for node in ranked_nodes),
+        visible_relationships=len(edge_filtered),
+        current_relationships=sum(edge.valid_to is None for edge in all_edges),
+        ownership_coverage=AtlasCoverageMetric(
+            numerator=len(sources_with_owner), denominator=len(source_nodes)
+        ),
+        evidence_coverage=AtlasCoverageMetric(
+            numerator=evidence_edges, denominator=len(edge_filtered)
+        ),
+        unresolved_source_links=unresolved,
+    )
+
+    return AtlasGraphResponse(
+        graph_version=_graph_version(all_nodes, all_edges),
+        generated_at=generated_at,
+        nodes=ranked_nodes,
+        edges=edge_filtered,
+        stats=stats,
+        applied_filters=filters,
+        truncated=truncated,
+        truncation_reason=",".join(reasons) if reasons else None,
+        next_expansion_token=(
+            filters.selected if truncated and filters.selected else None
+        ),
+    )
+
+
+async def build_atlas_stats(db: AsyncSession) -> AtlasStatsResponse:
+    filters = AtlasGraphFilters(
+        entity_types=["source", "organization", "reporter"],
+        limit_nodes=600,
+        limit_edges=2500,
+        include_evidence_preview=False,
+    )
+    graph = await build_atlas_graph(db, filters)
+    relation_counts = Counter(edge.relation_type for edge in graph.edges)
+    index_rows = list((await db.execute(select(WikiIndexStatus))).scalars().all())
+    index_counts = Counter(cast(str, row.status) for row in index_rows)
+    last_indexed_at = max(
+        (
+            cast(datetime, row.last_indexed_at)
+            for row in index_rows
+            if row.last_indexed_at
+        ),
+        default=None,
+    )
+    return AtlasStatsResponse(
+        graph_version=graph.graph_version,
+        generated_at=graph.generated_at,
+        stats=graph.stats,
+        by_entity_type={
+            "source": graph.stats.total_sources,
+            "organization": graph.stats.total_organizations,
+            "reporter": graph.stats.total_reporters,
+        },
+        by_relation_type=dict(relation_counts),
+        by_index_status=dict(index_counts),
+        last_indexed_at=last_indexed_at,
+        indexing_active=any(cast(str, row.status) == "indexing" for row in index_rows),
+    )
+
+
+def canonical_relation_type(value: str) -> AtlasRelationType | None:
+    return _RELATION_GROUPS.get(value)

--- a/backend/app/services/atlas_graph.py
+++ b/backend/app/services/atlas_graph.py
@@ -59,11 +59,7 @@ def _apply_neighborhood(
             queue.append((related, depth + 1))
     return (
         [node for node in nodes if node.id in visible],
-        [
-            edge
-            for edge in edges
-            if edge.source_id in visible and edge.target_id in visible
-        ],
+        [edge for edge in edges if edge.source_id in visible and edge.target_id in visible],
     )
 
 
@@ -108,8 +104,7 @@ def _rank_nodes(
 def _graph_version(nodes: list[AtlasNode], edges: list[AtlasEdge]) -> str:
     payload = {
         "nodes": sorted(
-            (node.id, node.updated_at.isoformat() if node.updated_at else "")
-            for node in nodes
+            (node.id, node.updated_at.isoformat() if node.updated_at else "") for node in nodes
         ),
         "edges": sorted(
             (
@@ -119,15 +114,12 @@ def _graph_version(nodes: list[AtlasNode], edges: list[AtlasEdge]) -> str:
             for edge in edges
         ),
     }
-    digest = hashlib.sha256(
-        json.dumps(payload, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
+    digest = hashlib.sha256(json.dumps(payload, separators=(",", ":")).encode("utf-8")).hexdigest()
     return digest[:20]
 
 
-async def build_atlas_graph(
-    db: AsyncSession, filters: AtlasGraphFilters
-) -> AtlasGraphResponse:
+async def build_atlas_graph(db: AsyncSession, filters: AtlasGraphFilters) -> AtlasGraphResponse:
+    """Build a bounded and filtered Atlas graph projection."""
     generated_at = datetime.now(UTC)
     (
         all_nodes,
@@ -141,12 +133,8 @@ async def build_atlas_graph(
     # A committed selection is a neighborhood lookup, not a label-only search.
     # Preserve q in the response contract/URL while allowing connected entities
     # that do not repeat the query text to remain visible.
-    node_match_filters = (
-        filters.model_copy(update={"q": None}) if filters.selected else filters
-    )
-    node_filtered = [
-        node for node in all_nodes if _node_matches(node, node_match_filters)
-    ]
+    node_match_filters = filters.model_copy(update={"q": None}) if filters.selected else filters
+    node_filtered = [node for node in all_nodes if _node_matches(node, node_match_filters)]
     allowed_node_ids = {node.id for node in node_filtered}
     edge_filtered = [
         edge
@@ -186,9 +174,7 @@ async def build_atlas_graph(
 
     evidence_edges = sum(1 for edge in edge_filtered if edge.evidence_count > 0)
     ownership_edges = [
-        edge
-        for edge in all_edges
-        if edge.relation_type in {"ownership", "owned_by", "parent_org"}
+        edge for edge in all_edges if edge.relation_type in {"ownership", "owned_by", "parent_org"}
     ]
     source_nodes = [node for node in all_nodes if node.entity_type == "source"]
     sources_with_owner = {
@@ -199,14 +185,10 @@ async def build_atlas_graph(
 
     stats = AtlasGraphStats(
         total_sources=len(source_nodes),
-        total_organizations=sum(
-            node.entity_type == "organization" for node in all_nodes
-        ),
+        total_organizations=sum(node.entity_type == "organization" for node in all_nodes),
         total_reporters=sum(node.entity_type == "reporter" for node in all_nodes),
         visible_sources=sum(node.entity_type == "source" for node in ranked_nodes),
-        visible_organizations=sum(
-            node.entity_type == "organization" for node in ranked_nodes
-        ),
+        visible_organizations=sum(node.entity_type == "organization" for node in ranked_nodes),
         visible_reporters=sum(node.entity_type == "reporter" for node in ranked_nodes),
         visible_relationships=len(edge_filtered),
         current_relationships=sum(edge.valid_to is None for edge in all_edges),
@@ -228,13 +210,12 @@ async def build_atlas_graph(
         applied_filters=filters,
         truncated=truncated,
         truncation_reason=",".join(reasons) if reasons else None,
-        next_expansion_token=(
-            filters.selected if truncated and filters.selected else None
-        ),
+        next_expansion_token=(filters.selected if truncated and filters.selected else None),
     )
 
 
 async def build_atlas_stats(db: AsyncSession) -> AtlasStatsResponse:
+    """Build aggregate Atlas graph and indexing statistics."""
     filters = AtlasGraphFilters(
         entity_types=["source", "organization", "reporter"],
         limit_nodes=600,
@@ -246,11 +227,7 @@ async def build_atlas_stats(db: AsyncSession) -> AtlasStatsResponse:
     index_rows = list((await db.execute(select(WikiIndexStatus))).scalars().all())
     index_counts = Counter(cast(str, row.status) for row in index_rows)
     last_indexed_at = max(
-        (
-            cast(datetime, row.last_indexed_at)
-            for row in index_rows
-            if row.last_indexed_at
-        ),
+        (row.last_indexed_at for row in index_rows if row.last_indexed_at),
         default=None,
     )
     return AtlasStatsResponse(
@@ -262,7 +239,7 @@ async def build_atlas_stats(db: AsyncSession) -> AtlasStatsResponse:
             "organization": graph.stats.total_organizations,
             "reporter": graph.stats.total_reporters,
         },
-        by_relation_type=dict(relation_counts),
+        by_relation_type={str(key): value for key, value in relation_counts.items()},
         by_index_status=dict(index_counts),
         last_indexed_at=last_indexed_at,
         indexing_active=any(cast(str, row.status) == "indexing" for row in index_rows),
@@ -270,4 +247,5 @@ async def build_atlas_stats(db: AsyncSession) -> AtlasStatsResponse:
 
 
 def canonical_relation_type(value: str) -> AtlasRelationType | None:
+    """Map a raw relationship label to its canonical Atlas type."""
     return _RELATION_GROUPS.get(value)

--- a/backend/app/services/atlas_graph_helpers.py
+++ b/backend/app/services/atlas_graph_helpers.py
@@ -1,0 +1,203 @@
+"""Shared normalization and trust helpers for Intelligence Atlas graph services."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime
+from typing import Any, Iterable, cast
+
+from app.data.rss_sources import get_rss_sources
+from app.database import Reporter, SourceClaim, SourceClaimEvidence
+from app.models.atlas import (
+    AtlasConfidenceTier,
+    AtlasEdge,
+    AtlasEvidenceRef,
+    AtlasGraphFilters,
+    AtlasNode,
+    AtlasRelationType,
+)
+
+_OWNER_CLAIM_TYPES = {"parent_company", "owner", "ownership", "owned_by"}
+_LEGAL_ENTITY_CLAIM_TYPES = {"legal_entity_name", "organization"}
+_RELATION_GROUPS: dict[str, AtlasRelationType] = {
+    "ownership": "ownership",
+    "owned_by": "owned_by",
+    "parent_org": "parent_org",
+    "part_of": "part_of",
+    "publishes": "publishes",
+    "employed_by": "employed_by",
+    "current_outlet": "current_outlet",
+    "current_outlet_verified": "current_outlet",
+    "historical_outlet": "employed_by",
+    "article_attributed_to_source": "current_outlet",
+    "coauthor": "coauthor",
+    "shared_outlet": "shared_outlet",
+}
+
+
+def normalize_entity_label(value: str | None) -> str:
+    """Normalize an entity label for exact alias matching, never substring matching."""
+
+    if not value:
+        return ""
+    lowered = value.casefold().strip()
+    lowered = re.sub(r"[\W_]+", " ", lowered, flags=re.UNICODE)
+    return " ".join(lowered.split())
+
+
+def stable_source_id(source_name: str) -> str:
+    normalized = normalize_entity_label(source_name)
+    digest = hashlib.sha1(
+        normalized.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:12]
+    return f"source:{digest}"
+
+
+def confidence_tier(value: float | None, *, stale: bool = False) -> AtlasConfidenceTier:
+    if stale:
+        return "stale"
+    if value is None:
+        return "unresolved"
+    if value >= 0.9:
+        return "verified"
+    if value >= 0.75:
+        return "strong"
+    if value >= 0.5:
+        return "likely"
+    return "unresolved"
+
+
+def reporter_confidence_tier(reporter: Reporter) -> AtlasConfidenceTier:
+    """Person-level verification requires a person profile, not only repeated bylines."""
+
+    has_person_profile = bool(reporter.author_page_url or reporter.canonical_author_url)
+    if reporter.match_status == "matched" and has_person_profile:
+        return "verified"
+    if has_person_profile and reporter.research_confidence in {"high", "verified"}:
+        return "strong"
+    if reporter.match_status in {"matched", "ambiguous"}:
+        return "likely"
+    return "unresolved"
+
+
+def _catalog_sources() -> dict[str, dict[str, Any]]:
+    unique: dict[str, dict[str, Any]] = {}
+    for raw_name, raw_config in get_rss_sources().items():
+        name = raw_name.split(" - ")[0].strip()
+        unique.setdefault(name, cast(dict[str, Any], raw_config))
+    return unique
+
+
+def _claim_name(claim: SourceClaim) -> str:
+    value = claim.claim_value
+    if not isinstance(value, dict):
+        return ""
+    for key in ("name", "organization", "owner", "parent_company"):
+        raw = value.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return ""
+
+
+def _edge_id(
+    source_id: str, target_id: str, relation: str, discriminator: str = ""
+) -> str:
+    raw = f"{source_id}|{target_id}|{relation}|{discriminator}"
+    digest = hashlib.sha1(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+    return f"edge:{digest}"
+
+
+def _parse_percentage(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    else:
+        match = re.search(r"\d+(?:\.\d+)?", str(value))
+        if not match:
+            return None
+        number = float(match.group(0))
+    if number > 1:
+        return min(number, 100.0)
+    return max(number * 100.0, 0.0)
+
+
+def _research_confidence(value: str | None) -> float | None:
+    normalized = (value or "").strip().casefold()
+    return {
+        "verified": 0.95,
+        "high": 0.85,
+        "medium": 0.65,
+        "low": 0.4,
+        "ambiguous": 0.45,
+    }.get(normalized)
+
+
+def _evidence_ref(row: SourceClaimEvidence) -> AtlasEvidenceRef:
+    return AtlasEvidenceRef(
+        id=f"source-claim-evidence:{row.id}",
+        source_type=cast(str, row.source_type),
+        source_name=cast(str | None, row.source_name),
+        source_url=cast(str | None, row.source_url),
+        retrieved_at=cast(datetime | None, row.retrieved_at),
+        excerpt=cast(str | None, row.raw_excerpt),
+    )
+
+
+def _node_matches(node: AtlasNode, filters: AtlasGraphFilters) -> bool:
+    if filters.entity_types and node.entity_type not in filters.entity_types:
+        return False
+    if filters.country and (node.country_code or "").casefold() not in {
+        value.casefold() for value in filters.country
+    }:
+        return False
+    if filters.funding and (node.funding_type or "").casefold() not in {
+        value.casefold() for value in filters.funding
+    }:
+        return False
+    if filters.bias and (node.bias_rating or "").casefold() not in {
+        value.casefold() for value in filters.bias
+    }:
+        return False
+    if filters.q:
+        query = filters.q.casefold().strip()
+        haystack = " ".join(
+            value
+            for value in (
+                node.label,
+                node.subtitle or "",
+                node.country_code or "",
+                node.funding_type or "",
+                node.bias_rating or "",
+            )
+            if value
+        ).casefold()
+        if query not in haystack:
+            return False
+    return True
+
+
+def _edge_matches(edge: AtlasEdge, filters: AtlasGraphFilters) -> bool:
+    if filters.relation_types and edge.relation_type not in filters.relation_types:
+        return False
+    if edge.confidence is not None and edge.confidence < filters.min_confidence:
+        return False
+    if edge.confidence is None and filters.min_confidence > 0:
+        return False
+    return True
+
+
+def _dedupe_edges(edges: Iterable[AtlasEdge]) -> list[AtlasEdge]:
+    best: dict[tuple[str, str, str], AtlasEdge] = {}
+    for edge in edges:
+        key = (edge.source_id, edge.target_id, edge.relation_type)
+        current = best.get(key)
+        if current is None:
+            best[key] = edge
+            continue
+        current_score = (current.confidence or 0.0, current.evidence_count)
+        candidate_score = (edge.confidence or 0.0, edge.evidence_count)
+        if candidate_score > current_score:
+            best[key] = edge
+    return list(best.values())

--- a/backend/app/services/atlas_graph_helpers.py
+++ b/backend/app/services/atlas_graph_helpers.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import re
-from datetime import datetime
-from typing import Any, Iterable, cast
+from collections.abc import Iterable
+from typing import Any, cast
 
 from app.data.rss_sources import get_rss_sources
 from app.database import Reporter, SourceClaim, SourceClaimEvidence
@@ -38,7 +38,6 @@ _RELATION_GROUPS: dict[str, AtlasRelationType] = {
 
 def normalize_entity_label(value: str | None) -> str:
     """Normalize an entity label for exact alias matching, never substring matching."""
-
     if not value:
         return ""
     lowered = value.casefold().strip()
@@ -47,14 +46,14 @@ def normalize_entity_label(value: str | None) -> str:
 
 
 def stable_source_id(source_name: str) -> str:
+    """Build a stable public ID from a normalized source name."""
     normalized = normalize_entity_label(source_name)
-    digest = hashlib.sha1(
-        normalized.encode("utf-8"), usedforsecurity=False
-    ).hexdigest()[:12]
+    digest = hashlib.sha1(normalized.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
     return f"source:{digest}"
 
 
 def confidence_tier(value: float | None, *, stale: bool = False) -> AtlasConfidenceTier:
+    """Map a confidence score and freshness state to an Atlas tier."""
     if stale:
         return "stale"
     if value is None:
@@ -70,7 +69,6 @@ def confidence_tier(value: float | None, *, stale: bool = False) -> AtlasConfide
 
 def reporter_confidence_tier(reporter: Reporter) -> AtlasConfidenceTier:
     """Person-level verification requires a person profile, not only repeated bylines."""
-
     has_person_profile = bool(reporter.author_page_url or reporter.canonical_author_url)
     if reporter.match_status == "matched" and has_person_profile:
         return "verified"
@@ -85,7 +83,7 @@ def _catalog_sources() -> dict[str, dict[str, Any]]:
     unique: dict[str, dict[str, Any]] = {}
     for raw_name, raw_config in get_rss_sources().items():
         name = raw_name.split(" - ")[0].strip()
-        unique.setdefault(name, cast(dict[str, Any], raw_config))
+        unique.setdefault(name, raw_config)
     return unique
 
 
@@ -100,9 +98,7 @@ def _claim_name(claim: SourceClaim) -> str:
     return ""
 
 
-def _edge_id(
-    source_id: str, target_id: str, relation: str, discriminator: str = ""
-) -> str:
+def _edge_id(source_id: str, target_id: str, relation: str, discriminator: str = "") -> str:
     raw = f"{source_id}|{target_id}|{relation}|{discriminator}"
     digest = hashlib.sha1(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
     return f"edge:{digest}"
@@ -138,10 +134,10 @@ def _evidence_ref(row: SourceClaimEvidence) -> AtlasEvidenceRef:
     return AtlasEvidenceRef(
         id=f"source-claim-evidence:{row.id}",
         source_type=cast(str, row.source_type),
-        source_name=cast(str | None, row.source_name),
-        source_url=cast(str | None, row.source_url),
-        retrieved_at=cast(datetime | None, row.retrieved_at),
-        excerpt=cast(str | None, row.raw_excerpt),
+        source_name=row.source_name,
+        source_url=row.source_url,
+        retrieved_at=row.retrieved_at,
+        excerpt=row.raw_excerpt,
     )
 
 
@@ -183,9 +179,7 @@ def _edge_matches(edge: AtlasEdge, filters: AtlasGraphFilters) -> bool:
         return False
     if edge.confidence is not None and edge.confidence < filters.min_confidence:
         return False
-    if edge.confidence is None and filters.min_confidence > 0:
-        return False
-    return True
+    return not (edge.confidence is None and filters.min_confidence > 0)
 
 
 def _dedupe_edges(edges: Iterable[AtlasEdge]) -> list[AtlasEdge]:

--- a/backend/app/services/atlas_graph_projection.py
+++ b/backend/app/services/atlas_graph_projection.py
@@ -1,0 +1,450 @@
+"""Database projection for the Intelligence Atlas graph."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime
+from typing import Any, cast
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import (
+    Article,
+    Organization,
+    Reporter,
+    SourceClaim,
+    SourceClaimEvidence,
+    SourceMetadata,
+    WikiIndexStatus,
+)
+from app.models.atlas import (
+    AtlasEdge,
+    AtlasEvidenceRef,
+    AtlasGraphFilters,
+    AtlasNode,
+    AtlasRelationType,
+)
+from app.services.atlas_graph_helpers import (
+    _LEGAL_ENTITY_CLAIM_TYPES,
+    _OWNER_CLAIM_TYPES,
+    _catalog_sources,
+    _claim_name,
+    _dedupe_edges,
+    _edge_id,
+    _evidence_ref,
+    _parse_percentage,
+    _research_confidence,
+    confidence_tier,
+    normalize_entity_label,
+    reporter_confidence_tier,
+    stable_source_id,
+)
+
+
+async def _load_graph_projection(
+    db: AsyncSession,
+    filters: AtlasGraphFilters,
+) -> tuple[
+    list[AtlasNode], list[AtlasEdge], int, dict[str, int], datetime | None, bool
+]:
+    catalog = _catalog_sources()
+    orgs = list((await db.execute(select(Organization))).scalars().all())
+    metadata = list((await db.execute(select(SourceMetadata))).scalars().all())
+    claims = list(
+        (await db.execute(select(SourceClaim).where(SourceClaim.is_current.is_(True))))
+        .scalars()
+        .all()
+    )
+    claim_ids = [cast(int, claim.id) for claim in claims if claim.id is not None]
+    evidence_rows: list[SourceClaimEvidence] = []
+    if claim_ids:
+        evidence_rows = list(
+            (
+                await db.execute(
+                    select(SourceClaimEvidence).where(
+                        SourceClaimEvidence.claim_id.in_(claim_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    reporter_enabled = (
+        not filters.entity_types
+        or "reporter" in filters.entity_types
+        or bool(filters.selected and filters.selected.startswith("reporter:"))
+    )
+    reporters: list[Reporter] = []
+    if reporter_enabled:
+        reporter_stmt = (
+            select(Reporter)
+            .where(Reporter.article_count > 0)
+            .order_by(Reporter.article_count.desc())
+            .limit(min(max(filters.limit_nodes, 50), 600))
+        )
+        reporters = list((await db.execute(reporter_stmt)).scalars().all())
+
+    article_counts = {
+        cast(str, source): int(count)
+        for source, count in (
+            await db.execute(
+                select(Article.source, func.count(Article.id)).group_by(Article.source)
+            )
+        ).all()
+    }
+
+    index_rows = list((await db.execute(select(WikiIndexStatus))).scalars().all())
+    index_by_key = {
+        (
+            cast(str, row.entity_type),
+            normalize_entity_label(cast(str, row.entity_name)),
+        ): row
+        for row in index_rows
+    }
+    index_counts = Counter(cast(str, row.status) for row in index_rows)
+    last_indexed_at = max(
+        (
+            cast(datetime, row.last_indexed_at)
+            for row in index_rows
+            if row.last_indexed_at
+        ),
+        default=None,
+    )
+    indexing_active = any(cast(str, row.status) == "indexing" for row in index_rows)
+
+    metadata_by_source = {
+        normalize_entity_label(cast(str, row.source_name)): row for row in metadata
+    }
+    evidence_by_claim: dict[int, list[AtlasEvidenceRef]] = defaultdict(list)
+    for row in evidence_rows:
+        evidence_by_claim[cast(int, row.claim_id)].append(_evidence_ref(row))
+    claims_by_source: dict[str, list[SourceClaim]] = defaultdict(list)
+    for claim in claims:
+        claims_by_source[normalize_entity_label(cast(str, claim.source_name))].append(
+            claim
+        )
+
+    org_alias_to_id: dict[str, int] = {}
+    org_by_id: dict[int, Organization] = {}
+    for org in orgs:
+        org_id = cast(int, org.id)
+        org_by_id[org_id] = org
+        for alias in (cast(str, org.name), cast(str | None, org.normalized_name)):
+            normalized = normalize_entity_label(alias)
+            if normalized:
+                org_alias_to_id.setdefault(normalized, org_id)
+
+    nodes: list[AtlasNode] = []
+    edges: list[AtlasEdge] = []
+    unresolved_source_links = 0
+
+    source_id_by_normalized: dict[str, str] = {}
+    source_name_by_id: dict[str, str] = {}
+    for source_name, config in catalog.items():
+        normalized = normalize_entity_label(source_name)
+        source_id = stable_source_id(source_name)
+        source_id_by_normalized[normalized] = source_id
+        source_name_by_id[source_id] = source_name
+        meta = metadata_by_source.get(normalized)
+        status = index_by_key.get(("source", normalized))
+        article_count = article_counts.get(source_name, 0)
+        nodes.append(
+            AtlasNode(
+                id=source_id,
+                entity_type="source",
+                label=source_name,
+                subtitle=cast(
+                    str | None,
+                    (meta.source_type if meta else None) or config.get("category"),
+                ),
+                country_code=cast(
+                    str | None,
+                    (meta.country if meta else None) or config.get("country"),
+                ),
+                funding_type=cast(
+                    str | None,
+                    (meta.funding_type if meta else None) or config.get("funding_type"),
+                ),
+                bias_rating=cast(
+                    str | None,
+                    (meta.political_bias if meta else None)
+                    or config.get("bias_rating"),
+                ),
+                factual_reporting=cast(
+                    str | None,
+                    (meta.factual_rating if meta else None)
+                    or config.get("factual_reporting"),
+                ),
+                credibility_score=cast(
+                    float | None, meta.credibility_score if meta else None
+                ),
+                article_count=article_count,
+                status=cast(str | None, status.status if status else None),
+                confidence_tier=confidence_tier(
+                    _research_confidence(cast(str | None, meta.research_confidence))
+                    if meta
+                    else None
+                ),
+                profile_path=f"/wiki/source/{source_name}",
+                updated_at=cast(
+                    datetime | None,
+                    (status.last_indexed_at if status else None)
+                    or (meta.updated_at if meta else None),
+                ),
+                flags=["needs-review"]
+                if status and cast(str, status.status) in {"failed", "stale"}
+                else [],
+            )
+        )
+
+    for org in orgs:
+        org_id = cast(int, org.id)
+        normalized = normalize_entity_label(cast(str, org.name))
+        status = index_by_key.get(("organization", normalized))
+        nodes.append(
+            AtlasNode(
+                id=f"organization:{org_id}",
+                entity_type="organization",
+                label=cast(str, org.name),
+                subtitle=cast(str | None, org.org_type),
+                funding_type=cast(str | None, org.funding_type),
+                bias_rating=cast(str | None, org.media_bias_rating),
+                factual_reporting=cast(str | None, org.factual_reporting),
+                status=cast(str | None, status.status if status else None),
+                confidence_tier=confidence_tier(
+                    _research_confidence(cast(str | None, org.research_confidence))
+                ),
+                profile_path=f"/wiki/ownership?selected=organization:{org_id}",
+                updated_at=cast(
+                    datetime | None,
+                    (status.last_indexed_at if status else None) or org.updated_at,
+                ),
+            )
+        )
+
+    for reporter in reporters:
+        reporter_id = cast(int, reporter.id)
+        normalized = normalize_entity_label(cast(str, reporter.name))
+        status = index_by_key.get(("reporter", normalized))
+        nodes.append(
+            AtlasNode(
+                id=f"reporter:{reporter_id}",
+                entity_type="reporter",
+                label=cast(str, reporter.canonical_name or reporter.name),
+                subtitle="Reporter",
+                article_count=int(reporter.article_count or 0),
+                bias_rating=cast(str | None, reporter.political_leaning),
+                status=cast(
+                    str | None, status.status if status else reporter.match_status
+                ),
+                confidence_tier=reporter_confidence_tier(reporter),
+                profile_path=f"/wiki/reporter/{reporter_id}",
+                updated_at=cast(
+                    datetime | None,
+                    (status.last_indexed_at if status else None) or reporter.updated_at,
+                ),
+            )
+        )
+
+    # Organization-to-organization links are exact ID or exact normalized alias links.
+    for org in orgs:
+        child_id = f"organization:{cast(int, org.id)}"
+        org_confidence = _research_confidence(cast(str | None, org.research_confidence))
+        if org.parent_org_id and cast(int, org.parent_org_id) in org_by_id:
+            parent_id = f"organization:{cast(int, org.parent_org_id)}"
+            edges.append(
+                AtlasEdge(
+                    id=_edge_id(parent_id, child_id, "ownership", str(org.id)),
+                    source_id=parent_id,
+                    target_id=child_id,
+                    relation_type="ownership",
+                    ownership_percentage=_parse_percentage(org.ownership_percentage),
+                    confidence=org_confidence or 0.85,
+                    confidence_tier=confidence_tier(org_confidence or 0.85),
+                    last_verified_at=cast(datetime | None, org.last_researched_at),
+                    raw_relation_type="parent_org_id",
+                )
+            )
+
+        alias_relations = (
+            (cast(list[Any], org.owned_by or []), "owned_by", False),
+            (cast(list[Any], org.parent_orgs or []), "parent_org", False),
+            (cast(list[Any], org.part_of or []), "part_of", True),
+        )
+        for values, relation, reverse in alias_relations:
+            for raw_name in values:
+                if not isinstance(raw_name, str):
+                    continue
+                related_org_id = org_alias_to_id.get(normalize_entity_label(raw_name))
+                if not related_org_id or related_org_id == org.id:
+                    continue
+                related_id = f"organization:{related_org_id}"
+                source_id, target_id = (
+                    (child_id, related_id) if reverse else (related_id, child_id)
+                )
+                relation_type = cast(AtlasRelationType, relation)
+                edges.append(
+                    AtlasEdge(
+                        id=_edge_id(source_id, target_id, relation, raw_name),
+                        source_id=source_id,
+                        target_id=target_id,
+                        relation_type=relation_type,
+                        confidence=org_confidence or 0.72,
+                        confidence_tier=confidence_tier(org_confidence or 0.72),
+                        last_verified_at=cast(datetime | None, org.last_researched_at),
+                        is_inferred=False,
+                        raw_relation_type=relation,
+                    )
+                )
+
+    # Source links: claims first, then explicit SourceMetadata parent_company, then exact legal identity.
+    for normalized_source, source_id in source_id_by_normalized.items():
+        source_claims = claims_by_source.get(normalized_source, [])
+        linked = False
+        for claim in source_claims:
+            claim_type = cast(str, claim.claim_type)
+            if claim_type not in _OWNER_CLAIM_TYPES | _LEGAL_ENTITY_CLAIM_TYPES:
+                continue
+            org_name = _claim_name(claim)
+            org_id = org_alias_to_id.get(normalize_entity_label(org_name))
+            if not org_id:
+                continue
+            relation: AtlasRelationType = (
+                "ownership" if claim_type in _OWNER_CLAIM_TYPES else "publishes"
+            )
+            organization_id = f"organization:{org_id}"
+            source_edge_id = organization_id
+            target_edge_id = source_id
+            evidence = evidence_by_claim.get(cast(int, claim.id), [])
+            confidence = float(claim.confidence or 0.0)
+            edges.append(
+                AtlasEdge(
+                    id=_edge_id(
+                        source_edge_id, target_edge_id, relation, str(claim.id)
+                    ),
+                    source_id=source_edge_id,
+                    target_id=target_edge_id,
+                    relation_type=relation,
+                    confidence=confidence,
+                    confidence_tier=confidence_tier(confidence),
+                    evidence_count=len(evidence),
+                    evidence_preview=evidence[:3]
+                    if filters.include_evidence_preview
+                    else [],
+                    valid_from=cast(datetime | None, claim.valid_from),
+                    valid_to=cast(datetime | None, claim.valid_to),
+                    last_verified_at=max(
+                        (item.retrieved_at for item in evidence if item.retrieved_at),
+                        default=cast(datetime | None, claim.updated_at),
+                    ),
+                    is_inferred=claim.claim_kind == "computed",
+                    raw_relation_type=claim_type,
+                )
+            )
+            linked = True
+
+        meta = metadata_by_source.get(normalized_source)
+        if meta and meta.parent_company:
+            org_id = org_alias_to_id.get(
+                normalize_entity_label(cast(str, meta.parent_company))
+            )
+            if org_id:
+                organization_id = f"organization:{org_id}"
+                edges.append(
+                    AtlasEdge(
+                        id=_edge_id(
+                            organization_id, source_id, "ownership", "source_metadata"
+                        ),
+                        source_id=organization_id,
+                        target_id=source_id,
+                        relation_type="ownership",
+                        confidence=0.68,
+                        confidence_tier="likely",
+                        evidence_count=0,
+                        last_verified_at=cast(datetime | None, meta.updated_at),
+                        is_inferred=True,
+                        raw_relation_type="source_metadata.parent_company",
+                    )
+                )
+                linked = True
+
+        exact_org_id = org_alias_to_id.get(normalized_source)
+        if exact_org_id:
+            organization_id = f"organization:{exact_org_id}"
+            edges.append(
+                AtlasEdge(
+                    id=_edge_id(organization_id, source_id, "publishes", "exact-label"),
+                    source_id=organization_id,
+                    target_id=source_id,
+                    relation_type="publishes",
+                    confidence=0.72,
+                    confidence_tier="likely",
+                    is_inferred=True,
+                    raw_relation_type="exact_canonical_label",
+                )
+            )
+            linked = True
+
+        if not linked:
+            unresolved_source_links += 1
+
+    # Reporter affiliations only use exact organization aliases. They never upgrade bylines to verification.
+    for reporter in reporters:
+        affiliations = reporter.institutional_affiliations or []
+        if not isinstance(affiliations, list):
+            continue
+        for affiliation in affiliations:
+            if not isinstance(affiliation, dict):
+                continue
+            raw_name = (
+                affiliation.get("org")
+                or affiliation.get("name")
+                or affiliation.get("organization")
+            )
+            if not isinstance(raw_name, str):
+                continue
+            org_id = org_alias_to_id.get(normalize_entity_label(raw_name))
+            if not org_id:
+                continue
+            evidence_url = affiliation.get("url") or affiliation.get("source_url")
+            evidence = []
+            if isinstance(evidence_url, str) and evidence_url:
+                evidence.append(
+                    AtlasEvidenceRef(
+                        id=f"reporter-affiliation:{reporter.id}:{org_id}",
+                        source_type="person_profile",
+                        source_name=cast(str, reporter.name),
+                        source_url=evidence_url,
+                        excerpt=cast(str | None, affiliation.get("role")),
+                    )
+                )
+            confidence = 0.9 if evidence else 0.62
+            source_id = f"reporter:{cast(int, reporter.id)}"
+            target_id = f"organization:{org_id}"
+            edges.append(
+                AtlasEdge(
+                    id=_edge_id(source_id, target_id, "employed_by", raw_name),
+                    source_id=source_id,
+                    target_id=target_id,
+                    relation_type="employed_by",
+                    confidence=confidence,
+                    confidence_tier=confidence_tier(confidence),
+                    evidence_count=len(evidence),
+                    evidence_preview=evidence
+                    if filters.include_evidence_preview
+                    else [],
+                    is_inferred=not bool(evidence),
+                    raw_relation_type="institutional_affiliation",
+                )
+            )
+
+    return (
+        nodes,
+        _dedupe_edges(edges),
+        unresolved_source_links,
+        dict(index_counts),
+        last_indexed_at,
+        indexing_active,
+    )

--- a/backend/app/services/atlas_graph_projection.py
+++ b/backend/app/services/atlas_graph_projection.py
@@ -45,9 +45,7 @@ from app.services.atlas_graph_helpers import (
 async def _load_graph_projection(
     db: AsyncSession,
     filters: AtlasGraphFilters,
-) -> tuple[
-    list[AtlasNode], list[AtlasEdge], int, dict[str, int], datetime | None, bool
-]:
+) -> tuple[list[AtlasNode], list[AtlasEdge], int, dict[str, int], datetime | None, bool]:
     catalog = _catalog_sources()
     orgs = list((await db.execute(select(Organization))).scalars().all())
     metadata = list((await db.execute(select(SourceMetadata))).scalars().all())
@@ -56,15 +54,13 @@ async def _load_graph_projection(
         .scalars()
         .all()
     )
-    claim_ids = [cast(int, claim.id) for claim in claims if claim.id is not None]
+    claim_ids = [claim.id for claim in claims if claim.id is not None]
     evidence_rows: list[SourceClaimEvidence] = []
     if claim_ids:
         evidence_rows = list(
             (
                 await db.execute(
-                    select(SourceClaimEvidence).where(
-                        SourceClaimEvidence.claim_id.in_(claim_ids)
-                    )
+                    select(SourceClaimEvidence).where(SourceClaimEvidence.claim_id.in_(claim_ids))
                 )
             )
             .scalars()
@@ -105,11 +101,7 @@ async def _load_graph_projection(
     }
     index_counts = Counter(cast(str, row.status) for row in index_rows)
     last_indexed_at = max(
-        (
-            cast(datetime, row.last_indexed_at)
-            for row in index_rows
-            if row.last_indexed_at
-        ),
+        (row.last_indexed_at for row in index_rows if row.last_indexed_at),
         default=None,
     )
     indexing_active = any(cast(str, row.status) == "indexing" for row in index_rows)
@@ -122,16 +114,14 @@ async def _load_graph_projection(
         evidence_by_claim[cast(int, row.claim_id)].append(_evidence_ref(row))
     claims_by_source: dict[str, list[SourceClaim]] = defaultdict(list)
     for claim in claims:
-        claims_by_source[normalize_entity_label(cast(str, claim.source_name))].append(
-            claim
-        )
+        claims_by_source[normalize_entity_label(cast(str, claim.source_name))].append(claim)
 
     org_alias_to_id: dict[str, int] = {}
     org_by_id: dict[int, Organization] = {}
     for org in orgs:
         org_id = cast(int, org.id)
         org_by_id[org_id] = org
-        for alias in (cast(str, org.name), cast(str | None, org.normalized_name)):
+        for alias in (cast(str, org.name), org.normalized_name):
             normalized = normalize_entity_label(alias)
             if normalized:
                 org_alias_to_id.setdefault(normalized, org_id)
@@ -169,30 +159,21 @@ async def _load_graph_projection(
                 ),
                 bias_rating=cast(
                     str | None,
-                    (meta.political_bias if meta else None)
-                    or config.get("bias_rating"),
+                    (meta.political_bias if meta else None) or config.get("bias_rating"),
                 ),
                 factual_reporting=cast(
                     str | None,
-                    (meta.factual_rating if meta else None)
-                    or config.get("factual_reporting"),
+                    (meta.factual_rating if meta else None) or config.get("factual_reporting"),
                 ),
-                credibility_score=cast(
-                    float | None, meta.credibility_score if meta else None
-                ),
+                credibility_score=cast(float | None, meta.credibility_score if meta else None),
                 article_count=article_count,
-                status=cast(str | None, status.status if status else None),
+                status=status.status if status else None,
                 confidence_tier=confidence_tier(
-                    _research_confidence(cast(str | None, meta.research_confidence))
-                    if meta
-                    else None
+                    _research_confidence(meta.research_confidence) if meta else None
                 ),
                 profile_path=f"/wiki/source/{source_name}",
-                updated_at=cast(
-                    datetime | None,
-                    (status.last_indexed_at if status else None)
-                    or (meta.updated_at if meta else None),
-                ),
+                updated_at=(status.last_indexed_at if status else None)
+                or (meta.updated_at if meta else None),
                 flags=["needs-review"]
                 if status and cast(str, status.status) in {"failed", "stale"}
                 else [],
@@ -200,32 +181,27 @@ async def _load_graph_projection(
         )
 
     for org in orgs:
-        org_id = cast(int, org.id)
+        org_pk = org.id
         normalized = normalize_entity_label(cast(str, org.name))
         status = index_by_key.get(("organization", normalized))
         nodes.append(
             AtlasNode(
-                id=f"organization:{org_id}",
+                id=f"organization:{org_pk}",
                 entity_type="organization",
                 label=cast(str, org.name),
-                subtitle=cast(str | None, org.org_type),
-                funding_type=cast(str | None, org.funding_type),
-                bias_rating=cast(str | None, org.media_bias_rating),
-                factual_reporting=cast(str | None, org.factual_reporting),
-                status=cast(str | None, status.status if status else None),
-                confidence_tier=confidence_tier(
-                    _research_confidence(cast(str | None, org.research_confidence))
-                ),
-                profile_path=f"/wiki/ownership?selected=organization:{org_id}",
-                updated_at=cast(
-                    datetime | None,
-                    (status.last_indexed_at if status else None) or org.updated_at,
-                ),
+                subtitle=org.org_type,
+                funding_type=org.funding_type,
+                bias_rating=org.media_bias_rating,
+                factual_reporting=org.factual_reporting,
+                status=status.status if status else None,
+                confidence_tier=confidence_tier(_research_confidence(org.research_confidence)),
+                profile_path=f"/wiki/ownership?selected=organization:{org_pk}",
+                updated_at=(status.last_indexed_at if status else None) or org.updated_at,
             )
         )
 
     for reporter in reporters:
-        reporter_id = cast(int, reporter.id)
+        reporter_id = reporter.id
         normalized = normalize_entity_label(cast(str, reporter.name))
         status = index_by_key.get(("reporter", normalized))
         nodes.append(
@@ -235,25 +211,20 @@ async def _load_graph_projection(
                 label=cast(str, reporter.canonical_name or reporter.name),
                 subtitle="Reporter",
                 article_count=int(reporter.article_count or 0),
-                bias_rating=cast(str | None, reporter.political_leaning),
-                status=cast(
-                    str | None, status.status if status else reporter.match_status
-                ),
+                bias_rating=reporter.political_leaning,
+                status=status.status if status else reporter.match_status,
                 confidence_tier=reporter_confidence_tier(reporter),
                 profile_path=f"/wiki/reporter/{reporter_id}",
-                updated_at=cast(
-                    datetime | None,
-                    (status.last_indexed_at if status else None) or reporter.updated_at,
-                ),
+                updated_at=(status.last_indexed_at if status else None) or reporter.updated_at,
             )
         )
 
     # Organization-to-organization links are exact ID or exact normalized alias links.
     for org in orgs:
-        child_id = f"organization:{cast(int, org.id)}"
-        org_confidence = _research_confidence(cast(str | None, org.research_confidence))
-        if org.parent_org_id and cast(int, org.parent_org_id) in org_by_id:
-            parent_id = f"organization:{cast(int, org.parent_org_id)}"
+        child_id = f"organization:{org.id}"
+        org_confidence = _research_confidence(org.research_confidence)
+        if org.parent_org_id and org.parent_org_id in org_by_id:
+            parent_id = f"organization:{org.parent_org_id}"
             edges.append(
                 AtlasEdge(
                     id=_edge_id(parent_id, child_id, "ownership", str(org.id)),
@@ -263,7 +234,7 @@ async def _load_graph_projection(
                     ownership_percentage=_parse_percentage(org.ownership_percentage),
                     confidence=org_confidence or 0.85,
                     confidence_tier=confidence_tier(org_confidence or 0.85),
-                    last_verified_at=cast(datetime | None, org.last_researched_at),
+                    last_verified_at=org.last_researched_at,
                     raw_relation_type="parent_org_id",
                 )
             )
@@ -273,7 +244,7 @@ async def _load_graph_projection(
             (cast(list[Any], org.parent_orgs or []), "parent_org", False),
             (cast(list[Any], org.part_of or []), "part_of", True),
         )
-        for values, relation, reverse in alias_relations:
+        for values, alias_relation, reverse in alias_relations:
             for raw_name in values:
                 if not isinstance(raw_name, str):
                     continue
@@ -281,21 +252,19 @@ async def _load_graph_projection(
                 if not related_org_id or related_org_id == org.id:
                     continue
                 related_id = f"organization:{related_org_id}"
-                source_id, target_id = (
-                    (child_id, related_id) if reverse else (related_id, child_id)
-                )
-                relation_type = cast(AtlasRelationType, relation)
+                source_id, target_id = (child_id, related_id) if reverse else (related_id, child_id)
+                relation_type = cast(AtlasRelationType, alias_relation)
                 edges.append(
                     AtlasEdge(
-                        id=_edge_id(source_id, target_id, relation, raw_name),
+                        id=_edge_id(source_id, target_id, alias_relation, raw_name),
                         source_id=source_id,
                         target_id=target_id,
                         relation_type=relation_type,
                         confidence=org_confidence or 0.72,
                         confidence_tier=confidence_tier(org_confidence or 0.72),
-                        last_verified_at=cast(datetime | None, org.last_researched_at),
+                        last_verified_at=org.last_researched_at,
                         is_inferred=False,
-                        raw_relation_type=relation,
+                        raw_relation_type=alias_relation,
                     )
                 )
 
@@ -308,36 +277,32 @@ async def _load_graph_projection(
             if claim_type not in _OWNER_CLAIM_TYPES | _LEGAL_ENTITY_CLAIM_TYPES:
                 continue
             org_name = _claim_name(claim)
-            org_id = org_alias_to_id.get(normalize_entity_label(org_name))
-            if not org_id:
+            source_org_id = org_alias_to_id.get(normalize_entity_label(org_name))
+            if not source_org_id:
                 continue
-            relation: AtlasRelationType = (
+            claim_relation: AtlasRelationType = (
                 "ownership" if claim_type in _OWNER_CLAIM_TYPES else "publishes"
             )
-            organization_id = f"organization:{org_id}"
+            organization_id = f"organization:{source_org_id}"
             source_edge_id = organization_id
             target_edge_id = source_id
             evidence = evidence_by_claim.get(cast(int, claim.id), [])
             confidence = float(claim.confidence or 0.0)
             edges.append(
                 AtlasEdge(
-                    id=_edge_id(
-                        source_edge_id, target_edge_id, relation, str(claim.id)
-                    ),
+                    id=_edge_id(source_edge_id, target_edge_id, claim_relation, str(claim.id)),
                     source_id=source_edge_id,
                     target_id=target_edge_id,
-                    relation_type=relation,
+                    relation_type=claim_relation,
                     confidence=confidence,
                     confidence_tier=confidence_tier(confidence),
                     evidence_count=len(evidence),
-                    evidence_preview=evidence[:3]
-                    if filters.include_evidence_preview
-                    else [],
-                    valid_from=cast(datetime | None, claim.valid_from),
-                    valid_to=cast(datetime | None, claim.valid_to),
+                    evidence_preview=evidence[:3] if filters.include_evidence_preview else [],
+                    valid_from=claim.valid_from,
+                    valid_to=claim.valid_to,
                     last_verified_at=max(
                         (item.retrieved_at for item in evidence if item.retrieved_at),
-                        default=cast(datetime | None, claim.updated_at),
+                        default=claim.updated_at,
                     ),
                     is_inferred=claim.claim_kind == "computed",
                     raw_relation_type=claim_type,
@@ -347,23 +312,19 @@ async def _load_graph_projection(
 
         meta = metadata_by_source.get(normalized_source)
         if meta and meta.parent_company:
-            org_id = org_alias_to_id.get(
-                normalize_entity_label(cast(str, meta.parent_company))
-            )
-            if org_id:
-                organization_id = f"organization:{org_id}"
+            metadata_org_id = org_alias_to_id.get(normalize_entity_label(meta.parent_company))
+            if metadata_org_id:
+                organization_id = f"organization:{metadata_org_id}"
                 edges.append(
                     AtlasEdge(
-                        id=_edge_id(
-                            organization_id, source_id, "ownership", "source_metadata"
-                        ),
+                        id=_edge_id(organization_id, source_id, "ownership", "source_metadata"),
                         source_id=organization_id,
                         target_id=source_id,
                         relation_type="ownership",
                         confidence=0.68,
                         confidence_tier="likely",
                         evidence_count=0,
-                        last_verified_at=cast(datetime | None, meta.updated_at),
+                        last_verified_at=meta.updated_at,
                         is_inferred=True,
                         raw_relation_type="source_metadata.parent_company",
                     )
@@ -399,21 +360,19 @@ async def _load_graph_projection(
             if not isinstance(affiliation, dict):
                 continue
             raw_name = (
-                affiliation.get("org")
-                or affiliation.get("name")
-                or affiliation.get("organization")
+                affiliation.get("org") or affiliation.get("name") or affiliation.get("organization")
             )
             if not isinstance(raw_name, str):
                 continue
-            org_id = org_alias_to_id.get(normalize_entity_label(raw_name))
-            if not org_id:
+            affiliation_org_id = org_alias_to_id.get(normalize_entity_label(raw_name))
+            if not affiliation_org_id:
                 continue
             evidence_url = affiliation.get("url") or affiliation.get("source_url")
             evidence = []
             if isinstance(evidence_url, str) and evidence_url:
                 evidence.append(
                     AtlasEvidenceRef(
-                        id=f"reporter-affiliation:{reporter.id}:{org_id}",
+                        id=f"reporter-affiliation:{reporter.id}:{affiliation_org_id}",
                         source_type="person_profile",
                         source_name=cast(str, reporter.name),
                         source_url=evidence_url,
@@ -421,8 +380,8 @@ async def _load_graph_projection(
                     )
                 )
             confidence = 0.9 if evidence else 0.62
-            source_id = f"reporter:{cast(int, reporter.id)}"
-            target_id = f"organization:{org_id}"
+            source_id = f"reporter:{reporter.id}"
+            target_id = f"organization:{affiliation_org_id}"
             edges.append(
                 AtlasEdge(
                     id=_edge_id(source_id, target_id, "employed_by", raw_name),
@@ -432,9 +391,7 @@ async def _load_graph_projection(
                     confidence=confidence,
                     confidence_tier=confidence_tier(confidence),
                     evidence_count=len(evidence),
-                    evidence_preview=evidence
-                    if filters.include_evidence_preview
-                    else [],
+                    evidence_preview=evidence if filters.include_evidence_preview else [],
                     is_inferred=not bool(evidence),
                     raw_relation_type="institutional_affiliation",
                 )

--- a/backend/scripts/backfill_atlas_relationships.py
+++ b/backend/scripts/backfill_atlas_relationships.py
@@ -34,14 +34,10 @@ class AuditRow:
 
 
 def _hash_payload(payload: dict[str, Any]) -> str:
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
-async def run_backfill(
-    *, dry_run: bool, source_only: str | None, audit_path: Path
-) -> None:
+async def run_backfill(*, dry_run: bool, source_only: str | None, audit_path: Path) -> None:
     if AsyncSessionLocal is None:
         raise RuntimeError("Database is disabled")
     async with AsyncSessionLocal() as session:
@@ -61,9 +57,9 @@ async def run_backfill(
         created = 0
         for row in metadata:
             source_name = cast(str, row.source_name)
-            if source_only and normalize_entity_label(
-                source_name
-            ) != normalize_entity_label(source_only):
+            if source_only and normalize_entity_label(source_name) != normalize_entity_label(
+                source_only
+            ):
                 continue
             parent_company = cast(str | None, row.parent_company)
             if not parent_company:
@@ -111,9 +107,7 @@ async def run_backfill(
                 .scalars()
                 .all()
             )
-            stronger = [
-                claim for claim in existing if float(claim.confidence or 0) >= 0.68
-            ]
+            stronger = [claim for claim in existing if float(claim.confidence or 0) >= 0.68]
             if stronger:
                 audits.append(
                     AuditRow(
@@ -146,7 +140,7 @@ async def run_backfill(
                 claim_type="parent_company",
                 claim_value=claim_value,
                 claim_kind="factual",
-                confidence=0.68,
+                confidence=cast(Any, 0.68),
                 parser_version="atlas-backfill/v1",
                 is_current=True,
                 valid_from=get_utc_now(),
@@ -193,9 +187,7 @@ async def run_backfill(
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--apply", action="store_true", help="Persist claims; default is dry run"
-    )
+    parser.add_argument("--apply", action="store_true", help="Persist claims; default is dry run")
     parser.add_argument("--source", help="Only process one source")
     parser.add_argument(
         "--audit",
@@ -204,9 +196,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     asyncio.run(
-        run_backfill(
-            dry_run=not args.apply, source_only=args.source, audit_path=args.audit
-        )
+        run_backfill(dry_run=not args.apply, source_only=args.source, audit_path=args.audit)
     )
 
 

--- a/backend/scripts/backfill_atlas_relationships.py
+++ b/backend/scripts/backfill_atlas_relationships.py
@@ -1,0 +1,214 @@
+"""Backfill exact Atlas source-to-organization claims without substring matching."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from sqlalchemy import select
+
+from app.database import (
+    AsyncSessionLocal,
+    Organization,
+    SourceClaim,
+    SourceClaimEvidence,
+    SourceMetadata,
+    get_utc_now,
+)
+from app.services.atlas_graph_helpers import normalize_entity_label
+
+
+@dataclass
+class AuditRow:
+    source_name: str
+    parent_company: str | None
+    result: str
+    organization_id: int | None = None
+    organization_name: str | None = None
+    reason: str | None = None
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+async def run_backfill(
+    *, dry_run: bool, source_only: str | None, audit_path: Path
+) -> None:
+    if AsyncSessionLocal is None:
+        raise RuntimeError("Database is disabled")
+    async with AsyncSessionLocal() as session:
+        orgs = list((await session.execute(select(Organization))).scalars().all())
+        metadata = list((await session.execute(select(SourceMetadata))).scalars().all())
+        aliases: dict[str, list[Organization]] = {}
+        for org in orgs:
+            for raw_alias in (
+                cast(str, org.name),
+                cast(str | None, org.normalized_name),
+            ):
+                alias = normalize_entity_label(raw_alias)
+                if alias:
+                    aliases.setdefault(alias, []).append(org)
+
+        audits: list[AuditRow] = []
+        created = 0
+        for row in metadata:
+            source_name = cast(str, row.source_name)
+            if source_only and normalize_entity_label(
+                source_name
+            ) != normalize_entity_label(source_only):
+                continue
+            parent_company = cast(str | None, row.parent_company)
+            if not parent_company:
+                audits.append(
+                    AuditRow(
+                        source_name,
+                        None,
+                        "unresolved",
+                        reason="no parent_company metadata",
+                    )
+                )
+                continue
+            matches = aliases.get(normalize_entity_label(parent_company), [])
+            if not matches:
+                audits.append(
+                    AuditRow(
+                        source_name,
+                        parent_company,
+                        "unresolved",
+                        reason="no exact organization alias",
+                    )
+                )
+                continue
+            if len(matches) > 1:
+                audits.append(
+                    AuditRow(
+                        source_name,
+                        parent_company,
+                        "ambiguous",
+                        reason="multiple exact organization aliases",
+                    )
+                )
+                continue
+            org = matches[0]
+            existing = (
+                (
+                    await session.execute(
+                        select(SourceClaim).where(
+                            SourceClaim.source_name == source_name,
+                            SourceClaim.claim_type == "parent_company",
+                            SourceClaim.is_current.is_(True),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            stronger = [
+                claim for claim in existing if float(claim.confidence or 0) >= 0.68
+            ]
+            if stronger:
+                audits.append(
+                    AuditRow(
+                        source_name,
+                        parent_company,
+                        "retained",
+                        cast(int, org.id),
+                        cast(str, org.name),
+                        "existing equal-or-stronger claim",
+                    )
+                )
+                continue
+            audits.append(
+                AuditRow(
+                    source_name,
+                    parent_company,
+                    "linked",
+                    cast(int, org.id),
+                    cast(str, org.name),
+                )
+            )
+            if dry_run:
+                continue
+            claim_value = {
+                "name": cast(str, org.name),
+                "organization_id": cast(int, org.id),
+            }
+            claim = SourceClaim(
+                source_name=source_name,
+                claim_type="parent_company",
+                claim_value=claim_value,
+                claim_kind="factual",
+                confidence=0.68,
+                parser_version="atlas-backfill/v1",
+                is_current=True,
+                valid_from=get_utc_now(),
+            )
+            session.add(claim)
+            await session.flush()
+            evidence_payload = {
+                "source_name": source_name,
+                "parent_company": parent_company,
+                "organization_id": cast(int, org.id),
+            }
+            session.add(
+                SourceClaimEvidence(
+                    claim_id=claim.id,
+                    source_type="source_metadata",
+                    source_name=source_name,
+                    source_url="urn:thesis:source-metadata",
+                    retrieved_at=get_utc_now(),
+                    raw_excerpt=f"parent_company={parent_company}",
+                    raw_hash=_hash_payload(evidence_payload),
+                )
+            )
+            created += 1
+
+        if not dry_run:
+            await session.commit()
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        audit_path.write_text(
+            json.dumps(
+                {
+                    "dry_run": dry_run,
+                    "created": created,
+                    "counts": {
+                        result: sum(item.result == result for item in audits)
+                        for result in {item.result for item in audits}
+                    },
+                    "rows": [asdict(item) for item in audits],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--apply", action="store_true", help="Persist claims; default is dry run"
+    )
+    parser.add_argument("--source", help="Only process one source")
+    parser.add_argument(
+        "--audit",
+        type=Path,
+        default=Path("artifacts/atlas-relationship-backfill.json"),
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        run_backfill(
+            dry_run=not args.apply, source_only=args.source, audit_path=args.audit
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_atlas_relationship_integrity.py
+++ b/backend/tests/test_atlas_relationship_integrity.py
@@ -14,9 +14,7 @@ def test_normalized_matching_is_exact_not_substring() -> None:
     assert normalize_entity_label("RT") == "rt"
     assert normalize_entity_label("Hartford Courant") == "hartford courant"
     assert normalize_entity_label("RT") != normalize_entity_label("Hartford Courant")
-    assert normalize_entity_label("Reuters") != normalize_entity_label(
-        "Thomson Reuters Foundation"
-    )
+    assert normalize_entity_label("Reuters") != normalize_entity_label("Thomson Reuters Foundation")
 
 
 def test_stable_source_ids_are_deterministic_and_distinct() -> None:

--- a/backend/tests/test_atlas_relationship_integrity.py
+++ b/backend/tests/test_atlas_relationship_integrity.py
@@ -1,0 +1,49 @@
+"""Regression tests for Atlas relationship matching and trust rules."""
+
+from types import SimpleNamespace
+
+from app.services.atlas_graph_helpers import (
+    confidence_tier,
+    normalize_entity_label,
+    reporter_confidence_tier,
+    stable_source_id,
+)
+
+
+def test_normalized_matching_is_exact_not_substring() -> None:
+    assert normalize_entity_label("RT") == "rt"
+    assert normalize_entity_label("Hartford Courant") == "hartford courant"
+    assert normalize_entity_label("RT") != normalize_entity_label("Hartford Courant")
+    assert normalize_entity_label("Reuters") != normalize_entity_label(
+        "Thomson Reuters Foundation"
+    )
+
+
+def test_stable_source_ids_are_deterministic_and_distinct() -> None:
+    assert stable_source_id("Reuters") == stable_source_id(" Reuters ")
+    assert stable_source_id("RT") != stable_source_id("Hartford Courant")
+
+
+def test_reporter_verification_requires_person_level_profile() -> None:
+    byline_only = SimpleNamespace(
+        author_page_url=None,
+        canonical_author_url=None,
+        match_status="matched",
+        research_confidence="high",
+    )
+    person_profile = SimpleNamespace(
+        author_page_url="https://example.com/authors/alex",
+        canonical_author_url=None,
+        match_status="matched",
+        research_confidence="high",
+    )
+    assert reporter_confidence_tier(byline_only) == "likely"
+    assert reporter_confidence_tier(person_profile) == "verified"
+
+
+def test_confidence_labels_are_explicit() -> None:
+    assert confidence_tier(0.95) == "verified"
+    assert confidence_tier(0.8) == "strong"
+    assert confidence_tier(0.6) == "likely"
+    assert confidence_tier(None) == "unresolved"
+    assert confidence_tier(0.95, stale=True) == "stale"

--- a/backend/tests/test_wiki_atlas_contract.py
+++ b/backend/tests/test_wiki_atlas_contract.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+
+from app.models.atlas import (
+    AtlasEdge,
+    AtlasGraphFilters,
+    AtlasGraphResponse,
+    AtlasGraphStats,
+    AtlasNode,
+)
+
+
+def test_graph_contract_rejects_unbounded_filter_values() -> None:
+    filters = AtlasGraphFilters(limit_nodes=350, limit_edges=1500)
+    assert filters.limit_nodes == 350
+    assert filters.limit_edges == 1500
+
+
+def test_graph_contract_keeps_stable_endpoint_ids() -> None:
+    node = AtlasNode(id="source:abc", entity_type="source", label="Example")
+    edge = AtlasEdge(
+        id="edge:1",
+        source_id="organization:1",
+        target_id=node.id,
+        relation_type="ownership",
+        confidence=0.9,
+        confidence_tier="verified",
+    )
+    response = AtlasGraphResponse(
+        graph_version="v1",
+        generated_at=datetime.now(UTC),
+        nodes=[node],
+        edges=[edge],
+        stats=AtlasGraphStats(),
+        applied_filters=AtlasGraphFilters(),
+    )
+    assert response.edges[0].target_id == response.nodes[0].id
+    assert response.graph_version == "v1"

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -1,5 +1,23 @@
 # Log
 
+## 2026-07-19 — Intelligence Atlas Review Fixes
+
+Repaired the Intelligence Atlas pull request before integration.
+
+- Removed React state-mirroring effects from graph focus, layout, and viewport fitting.
+- Kept Web Worker layout results keyed to their graph topology so stale results do not appear after filter or size changes.
+- Fixed graph zoom controls to use the SVG viewport center.
+- Replaced whole-hook dependencies in the Atlas index and workspace with the specific values and functions they use.
+- Corrected Atlas backend type mismatches in graph projection and evidence export, then brought the new routes, models, and services through the repository Ruff and strict mypy checks.
+
+Verification:
+
+- Atlas backend tests: 6 passed.
+- Atlas frontend tests: 3 passed.
+- Frontend lint: passed with one existing React Compiler warning for TanStack Virtual.
+- Frontend TypeScript check: passed.
+- Atlas backend Ruff and strict mypy checks: passed.
+
 ## 2026-05-26 — Reporter Confidence Evidence Correction
 
 Corrected the reporter verification model so `verified` requires person-level author/profile evidence instead of any public URL citation.

--- a/docs/agents/traces/review-pr-6-intelligence-atlas.md
+++ b/docs/agents/traces/review-pr-6-intelligence-atlas.md
@@ -1,0 +1,54 @@
+# Agent Trace
+
+## Goal and done criteria
+
+Review PR 6, repair blocking findings, and prove it can be integrated without losing the existing Atlas behavior.
+
+## Status
+
+Ready for combined-tree verification. The isolated worktree cannot run Turbopack with dependencies linked from the main checkout, so the production build must run after integration in the main worktree.
+
+## Risk
+
+Medium. The change adds public API routes, database projection logic, exports, and a new UI workspace.
+
+## Files changed during review
+
+- `backend/app/api/routes/wiki_atlas.py`
+- `backend/app/models/atlas.py`
+- `backend/app/services/atlas_entity.py`
+- `backend/app/services/atlas_export.py`
+- `backend/app/services/atlas_graph.py`
+- `backend/app/services/atlas_graph_helpers.py`
+- `backend/app/services/atlas_graph_projection.py`
+- `backend/scripts/backfill_atlas_relationships.py`
+- `frontend/features/intelligence-atlas/atlas-graph.tsx`
+- `frontend/features/intelligence-atlas/atlas-index-sheet.tsx`
+- `frontend/features/intelligence-atlas/hooks/use-atlas-layout.ts`
+- `frontend/features/intelligence-atlas/intelligence-atlas-workspace.tsx`
+- `docs/Log.md`
+
+## Commands and tests run
+
+| Command | Result |
+| --- | --- |
+| Atlas backend pytest targets | 6 passed |
+| Atlas frontend Jest targets | 3 passed |
+| Frontend ESLint | Passed with one TanStack Virtual compiler warning |
+| Frontend TypeScript check | Passed |
+| Ruff on Atlas backend files | Passed |
+| Strict mypy on Atlas backend files | Passed |
+| Frontend production build in isolated worktree | Blocked by dependency links crossing the worktree filesystem root |
+
+## Tests added
+
+No new tests. The review repairs are covered by the PR's Atlas contract, schema, and query-state tests plus lint and strict type checks.
+
+## Assumptions and risks
+
+- The final production build and browser verification will run on the combined main worktree, where dependencies are installed inside the repository root.
+- Database-backed Atlas behavior still depends on the local PostgreSQL data shape and will be exercised during combined verification when services are available.
+
+## Rollback
+
+Revert the review-fix commit while leaving the original PR commit intact.

--- a/docs/intelligence-atlas.md
+++ b/docs/intelligence-atlas.md
@@ -1,0 +1,44 @@
+# SCOOP Intelligence Atlas
+
+`/wiki/ownership` is the canonical investigation workspace for source, organization, reporter, and evidence relationships. The Atlas replaces the former always-visible three-column operations dashboard with a graph-first research surface while retaining the existing operator tools in a separate sheet.
+
+## Route state
+
+Shareable state is encoded in the query string: search, entity types, relation layers, country/funding/bias facets, minimum confidence, selected entity, neighborhood depth, focus mode, layout, and open panel. Browser back/forward therefore restores the investigation instead of resetting local component state.
+
+## API contracts
+
+The Atlas uses typed endpoints under `/api/wiki/atlas`:
+
+- `GET /graph` returns a bounded, internally consistent graph with a version, generation timestamp, filters, truncation state, typed nodes, typed relationships, confidence, and evidence previews.
+- `GET /stats` returns graph coverage with numerators and denominators.
+- `GET /search` returns grouped entity suggestions.
+- `GET /entities/{id}` and `/connections` return the record and traceable relationships.
+- `GET /index` provides server-filtered cursor pagination.
+- `POST /export` produces versioned JSON or CSV evidence bundles.
+
+The legacy `/api/wiki/organizations/graph` remains available during migration.
+
+## Trust rules
+
+The Atlas does not create ownership links through substring containment. Source-to-organization links come from current source claims, explicit source metadata, or exact canonical identity matches. Ambiguous candidates remain unresolved. Reporter verification requires person-level profile evidence; repeated bylines can support an outlet observation but do not independently verify identity.
+
+## Rendering and accessibility
+
+The default graph is bounded to 350 nodes and 1,500 relationships. Layout runs in a Web Worker and is deterministic for a graph version and layout mode. SVG is retained for the bounded production view. A synchronized semantic entity list, roving node focus, Enter/Space selection, arrow navigation, pointer pan, pointer-centered zoom, touch-safe pointer events, and reduced-motion behavior keep the graph operable without hover or a mouse.
+
+## Relationship backfill
+
+Run a dry audit first:
+
+```bash
+python backend/scripts/backfill_atlas_relationships.py
+```
+
+Apply only after reviewing `artifacts/atlas-relationship-backfill.json`:
+
+```bash
+python backend/scripts/backfill_atlas_relationships.py --apply
+```
+
+The backfill is idempotent with respect to equal-or-stronger current claims and never overwrites stronger manual evidence with its weaker metadata-derived claim.

--- a/frontend/app/wiki/ownership/error.tsx
+++ b/frontend/app/wiki/ownership/error.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function IntelligenceAtlasError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error("Intelligence Atlas route error", error);
+  }, [error]);
+
+  return (
+    <main className="grid min-h-screen place-items-center bg-[#080907] p-8 text-[#c9c3b6]">
+      <div className="max-w-lg rounded-3xl border border-red-400/20 bg-red-950/20 p-8 text-center">
+        <h1 className="font-serif text-3xl text-[#f0ede4]">The Atlas could not open</h1>
+        <p className="mt-3 text-sm leading-relaxed">{error.message || "The route failed before the bounded graph could be rendered."}</p>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-6 rounded-full border border-white/15 px-5 py-2 text-sm text-[#f0ede4] hover:border-[#d7b35f]/50"
+        >
+          Retry route
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/wiki/ownership/loading.tsx
+++ b/frontend/app/wiki/ownership/loading.tsx
@@ -1,0 +1,10 @@
+export default function IntelligenceAtlasLoading() {
+  return (
+    <main className="grid min-h-screen place-items-center bg-[#080907] text-[#c9c3b6]">
+      <div className="text-center">
+        <div className="font-serif text-3xl text-[#f0ede4]">Intelligence Atlas</div>
+        <div className="mt-3 font-mono text-[10px] uppercase tracking-[0.18em]">Loading graph contracts</div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/wiki/ownership/page.tsx
+++ b/frontend/app/wiki/ownership/page.tsx
@@ -1,11 +1,17 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
-import { SourceIntelligenceWorkspace } from "./source-intelligence-workspace";
+import { IntelligenceAtlasWorkspace } from "@/features/intelligence-atlas/intelligence-atlas-workspace";
 
 export const metadata: Metadata = {
-  title: "Source Intelligence",
+  title: "SCOOP Intelligence Atlas",
+  description: "Trace source, ownership, reporter, article, claim, and evidence relationships.",
 };
 
-export default function SourceIntelligencePage() {
-  return <SourceIntelligenceWorkspace />;
+export default function IntelligenceAtlasPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-[#080907]" aria-label="Loading Intelligence Atlas" />}>
+      <IntelligenceAtlasWorkspace />
+    </Suspense>
+  );
 }

--- a/frontend/components/navigation/navigation-config.ts
+++ b/frontend/components/navigation/navigation-config.ts
@@ -50,8 +50,8 @@ export const WIKI_NAVIGATION: readonly RouteNavigationItem[] = [
   },
   {
     href: "/wiki/ownership",
-    label: "Owner Graph",
-    description: "Trace ownership and funding relationships",
+    label: "Intelligence Atlas",
+    description: "Trace ownership, publishing, reporter, and evidence relationships",
     icon: Network,
     match: (pathname) => pathname.includes("/ownership"),
   },

--- a/frontend/features/intelligence-atlas/atlas-accessible-list.tsx
+++ b/frontend/features/intelligence-atlas/atlas-accessible-list.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { AtlasEdge, AtlasNode } from "./lib/atlas-schema";
+import styles from "./atlas.module.css";
+
+interface AtlasAccessibleListProps {
+  nodes: AtlasNode[];
+  edges: AtlasEdge[];
+  selectedId: string | null;
+  onSelect: (nodeId: string) => void;
+}
+
+export function AtlasAccessibleList({ nodes, edges, selectedId, onSelect }: AtlasAccessibleListProps) {
+  const relationCounts = new Map<string, number>();
+  edges.forEach((edge) => {
+    relationCounts.set(edge.source_id, (relationCounts.get(edge.source_id) ?? 0) + 1);
+    relationCounts.set(edge.target_id, (relationCounts.get(edge.target_id) ?? 0) + 1);
+  });
+
+  return (
+    <div className={styles.accessibleList} aria-label="Accessible Atlas entity list">
+      <h2>Atlas entities</h2>
+      <ul>
+        {nodes.map((node) => (
+          <li key={node.id}>
+            <button
+              type="button"
+              aria-pressed={selectedId === node.id}
+              onClick={() => onSelect(node.id)}
+            >
+              {node.label}, {node.entity_type}, {relationCounts.get(node.id) ?? 0} visible connections
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas-graph.tsx
+++ b/frontend/features/intelligence-atlas/atlas-graph.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+  type WheelEvent,
+} from "react";
+import { Minus, Plus, Scan } from "lucide-react";
+
+import { useAtlasLayout } from "./hooks/use-atlas-layout";
+import type { AtlasLayoutMode } from "./lib/atlas-query-state";
+import type { AtlasEdge, AtlasNode } from "./lib/atlas-schema";
+import { AtlasAccessibleList } from "./atlas-accessible-list";
+import styles from "./atlas.module.css";
+
+interface AtlasGraphProps {
+  nodes: AtlasNode[];
+  edges: AtlasEdge[];
+  graphVersion: string;
+  layout: AtlasLayoutMode;
+  selectedId: string | null;
+  focus: boolean;
+  loading: boolean;
+  onSelect: (nodeId: string) => void;
+}
+
+interface Transform {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+const ENTITY_FILL: Record<AtlasNode["entity_type"], string> = {
+  organization: "#d7b35f",
+  source: "#f0ede4",
+  reporter: "#88a9ff",
+};
+
+const EDGE_STROKE: Record<AtlasEdge["relation_type"], string> = {
+  ownership: "#d7b35f",
+  owned_by: "#b79348",
+  parent_org: "#b79348",
+  part_of: "#a88645",
+  publishes: "#b8b2a7",
+  employed_by: "#8ca0c8",
+  current_outlet: "#88a9ff",
+  coauthor: "#88a9ff",
+  shared_outlet: "#6f86bd",
+};
+
+function nodeRadius(node: AtlasNode): number {
+  const base = node.entity_type === "organization" ? 12 : node.entity_type === "source" ? 9 : 8;
+  const degree = Math.min(Math.log2(1 + node.connection_count) * 1.4, 8);
+  const articles = Math.min(Math.log10(1 + node.article_count) * 0.8, 3);
+  return base + degree + articles;
+}
+
+function nodeShape(node: AtlasNode, radius: number) {
+  if (node.entity_type === "source") {
+    return <rect x={-radius} y={-radius} width={radius * 2} height={radius * 2} rx={radius * 0.35} />;
+  }
+  if (node.entity_type === "reporter") {
+    return <path d={`M 0 ${-radius} C ${radius} ${-radius} ${radius} ${radius * 0.55} 0 ${radius} C ${-radius} ${radius * 0.55} ${-radius} ${-radius} 0 ${-radius} Z`} />;
+  }
+  return <circle r={radius} />;
+}
+
+export function AtlasGraph({
+  nodes,
+  edges,
+  graphVersion,
+  layout,
+  selectedId,
+  focus,
+  loading,
+  onSelect,
+}: AtlasGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 1280, height: 760 });
+  const [transform, setTransform] = useState<Transform>({ x: 0, y: 0, scale: 1 });
+  const [activeNodeId, setActiveNodeId] = useState<string | null>(selectedId);
+  const [panning, setPanning] = useState(false);
+  const panRef = useRef<{ pointerId: number; x: number; y: number; originX: number; originY: number } | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return;
+      setDimensions({
+        width: Math.max(320, Math.round(entry.contentRect.width)),
+        height: Math.max(360, Math.round(entry.contentRect.height)),
+      });
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const layoutOptions = useMemo(
+    () => ({
+      nodes,
+      edges,
+      width: dimensions.width,
+      height: dimensions.height,
+      layout,
+      selectedId,
+      graphVersion,
+    }),
+    [dimensions.height, dimensions.width, edges, graphVersion, layout, nodes, selectedId],
+  );
+  const { positions, stable } = useAtlasLayout(layoutOptions);
+  const selectedNeighbors = useMemo(() => {
+    const ids = new Set<string>();
+    if (!selectedId) return ids;
+    ids.add(selectedId);
+    edges.forEach((edge) => {
+      if (edge.source_id === selectedId) ids.add(edge.target_id);
+      if (edge.target_id === selectedId) ids.add(edge.source_id);
+    });
+    return ids;
+  }, [edges, selectedId]);
+  const orderedNodes = useMemo(
+    () => [...nodes].sort((left, right) => right.connection_count - left.connection_count || left.label.localeCompare(right.label)),
+    [nodes],
+  );
+
+  useEffect(() => {
+    if (selectedId) setActiveNodeId(selectedId);
+    else if (orderedNodes.length > 0 && !activeNodeId) setActiveNodeId(orderedNodes[0]!.id);
+  }, [activeNodeId, orderedNodes, selectedId]);
+
+  const fitGraph = useCallback(() => {
+    const values = Object.values(positions);
+    if (values.length === 0) return;
+    const xs = values.map((position) => position.x);
+    const ys = values.map((position) => position.y);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const padding = 90;
+    const width = Math.max(1, maxX - minX);
+    const height = Math.max(1, maxY - minY);
+    const scale = Math.min(
+      1.45,
+      Math.max(0.35, Math.min((dimensions.width - padding * 2) / width, (dimensions.height - padding * 2) / height)),
+    );
+    setTransform({
+      scale,
+      x: dimensions.width / 2 - ((minX + maxX) / 2) * scale,
+      y: dimensions.height / 2 - ((minY + maxY) / 2) * scale,
+    });
+  }, [dimensions.height, dimensions.width, positions]);
+
+  useEffect(() => {
+    if (stable) fitGraph();
+  }, [fitGraph, graphVersion, layout, stable]);
+
+  const zoomAt = useCallback((clientX: number, clientY: number, factor: number) => {
+    const bounds = svgRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+    const pointerX = clientX - bounds.left;
+    const pointerY = clientY - bounds.top;
+    setTransform((current) => {
+      const nextScale = Math.min(3.5, Math.max(0.3, current.scale * factor));
+      const worldX = (pointerX - current.x) / current.scale;
+      const worldY = (pointerY - current.y) / current.scale;
+      return {
+        scale: nextScale,
+        x: pointerX - worldX * nextScale,
+        y: pointerY - worldY * nextScale,
+      };
+    });
+  }, []);
+
+  function handleWheel(event: WheelEvent<SVGSVGElement>) {
+    event.preventDefault();
+    zoomAt(event.clientX, event.clientY, event.deltaY < 0 ? 1.12 : 1 / 1.12);
+  }
+
+  function handlePointerDown(event: PointerEvent<SVGSVGElement>) {
+    if (event.button !== 0 || (event.target as Element).closest("[data-node-id]")) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    panRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+      originX: transform.x,
+      originY: transform.y,
+    };
+    setPanning(true);
+  }
+
+  function handlePointerMove(event: PointerEvent<SVGSVGElement>) {
+    const pan = panRef.current;
+    if (!pan || pan.pointerId !== event.pointerId) return;
+    setTransform((current) => ({
+      ...current,
+      x: pan.originX + event.clientX - pan.x,
+      y: pan.originY + event.clientY - pan.y,
+    }));
+  }
+
+  function handlePointerUp(event: PointerEvent<SVGSVGElement>) {
+    if (panRef.current?.pointerId !== event.pointerId) return;
+    panRef.current = null;
+    setPanning(false);
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }
+
+  function handleNodeKeyboard(event: KeyboardEvent<SVGGElement>, nodeId: string) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onSelect(nodeId);
+      return;
+    }
+    if (!["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"].includes(event.key)) return;
+    event.preventDefault();
+    const currentIndex = orderedNodes.findIndex((node) => node.id === nodeId);
+    const direction = event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
+    const nextIndex = (currentIndex + direction + orderedNodes.length) % orderedNodes.length;
+    const nextNode = orderedNodes[nextIndex];
+    if (!nextNode) return;
+    setActiveNodeId(nextNode.id);
+    requestAnimationFrame(() => {
+      svgRef.current?.querySelector<SVGGElement>(`[data-node-id="${CSS.escape(nextNode.id)}"]`)?.focus();
+    });
+  }
+
+  if (nodes.length === 0 && !loading) {
+    return (
+      <div ref={containerRef} className={styles.emptyState}>
+        <div>
+          <div className={styles.brandTitle}>No entities match this view.</div>
+          <p className={styles.contextCopy}>Clear a filter or search for a different source, organization, or reporter.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative h-full w-full">
+      <svg
+        ref={svgRef}
+        className={styles.graphCanvas}
+        data-panning={panning}
+        role="group"
+        aria-label={`Intelligence Atlas graph with ${nodes.length} entities and ${edges.length} relationships`}
+        onWheel={handleWheel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        <defs>
+          <marker id="atlas-arrow-gold" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+            <path d="M0,0 L7,3.5 L0,7 Z" fill="#d7b35f" />
+          </marker>
+          <marker id="atlas-arrow-neutral" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+            <path d="M0,0 L7,3.5 L0,7 Z" fill="#b8b2a7" />
+          </marker>
+        </defs>
+        <g transform={`translate(${transform.x} ${transform.y}) scale(${transform.scale})`}>
+          {edges.map((edge) => {
+            const source = positions[edge.source_id];
+            const target = positions[edge.target_id];
+            if (!source || !target) return null;
+            const dimmed = focus && selectedId && !selectedNeighbors.has(edge.source_id) && !selectedNeighbors.has(edge.target_id);
+            const dashed = edge.is_inferred || edge.confidence_tier === "likely" || edge.confidence_tier === "unresolved";
+            return (
+              <line
+                key={edge.id}
+                className={styles.edge}
+                x1={source.x}
+                y1={source.y}
+                x2={target.x}
+                y2={target.y}
+                stroke={EDGE_STROKE[edge.relation_type]}
+                strokeOpacity={dimmed ? 0.08 : Math.max(0.22, edge.confidence ?? 0.55)}
+                strokeDasharray={dashed ? "5 5" : undefined}
+                markerEnd={edge.direction === "directed" ? `url(#${edge.relation_type === "ownership" ? "atlas-arrow-gold" : "atlas-arrow-neutral"})` : undefined}
+              />
+            );
+          })}
+          {nodes.map((node) => {
+            const position = positions[node.id];
+            if (!position) return null;
+            const radius = nodeRadius(node);
+            const selected = selectedId === node.id;
+            const active = activeNodeId === node.id;
+            const dimmed = focus && selectedId && !selectedNeighbors.has(node.id);
+            const confidence = node.confidence_tier ?? "unresolved";
+            return (
+              <g
+                key={node.id}
+                data-node-id={node.id}
+                className={styles.nodeButton}
+                transform={`translate(${position.x} ${position.y})`}
+                tabIndex={active ? 0 : -1}
+                role="button"
+                aria-label={`${node.label}, ${node.entity_type}, ${node.connection_count} connections, ${confidence} confidence`}
+                aria-pressed={selected}
+                opacity={dimmed ? 0.16 : 1}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setActiveNodeId(node.id);
+                  onSelect(node.id);
+                }}
+                onKeyDown={(event) => handleNodeKeyboard(event, node.id)}
+              >
+                <circle
+                  className={styles.nodeHalo}
+                  r={radius + (selected ? 8 : 5)}
+                  fill="transparent"
+                  stroke={selected ? "#d7b35f" : ENTITY_FILL[node.entity_type]}
+                  strokeOpacity={selected ? 0.9 : 0}
+                  strokeWidth={selected ? 2 : 1}
+                />
+                <g fill={ENTITY_FILL[node.entity_type]} fillOpacity={selected ? 1 : 0.82} stroke="#080907" strokeWidth={2}>
+                  {nodeShape(node, radius)}
+                </g>
+                {node.flags.includes("needs-review") ? (
+                  <circle cx={radius * 0.7} cy={-radius * 0.7} r={3.2} fill="#f1635e" stroke="#080907" strokeWidth={1.5} />
+                ) : null}
+                <text className={styles.nodeLabel} x={radius + 7} y={1} fill="#f0ede4">
+                  {node.label.length > 34 ? `${node.label.slice(0, 31)}…` : node.label}
+                </text>
+                <text className={styles.nodeMeta} x={radius + 7} y={13}>
+                  {node.entity_type} · {node.connection_count}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+
+      <div className="absolute bottom-24 left-5 z-10 flex gap-2">
+        <button
+          type="button"
+          className={styles.iconButton}
+          aria-label="Zoom in"
+          onClick={() => zoomAt(dimensions.width / 2, dimensions.height / 2, 1.18)}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className={styles.iconButton}
+          aria-label="Zoom out"
+          onClick={() => zoomAt(dimensions.width / 2, dimensions.height / 2, 1 / 1.18)}
+        >
+          <Minus className="h-4 w-4" />
+        </button>
+        <button type="button" className={styles.iconButton} aria-label="Fit visible graph" onClick={fitGraph}>
+          <Scan className="h-4 w-4" />
+        </button>
+      </div>
+      <div className={styles.graphStatus} aria-live="polite">
+        <span className={`h-1.5 w-1.5 rounded-full ${stable ? "bg-emerald-300" : "animate-pulse bg-amber-300"}`} />
+        {stable ? "Layout stable" : "Calculating layout"}
+      </div>
+      <AtlasAccessibleList nodes={nodes} edges={edges} selectedId={selectedId} onSelect={onSelect} />
+    </div>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas-graph.tsx
+++ b/frontend/features/intelligence-atlas/atlas-graph.tsx
@@ -83,8 +83,8 @@ export function AtlasGraph({
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const [dimensions, setDimensions] = useState({ width: 1280, height: 760 });
-  const [transform, setTransform] = useState<Transform>({ x: 0, y: 0, scale: 1 });
-  const [activeNodeId, setActiveNodeId] = useState<string | null>(selectedId);
+  const [manualTransform, setManualTransform] = useState<{ key: string; value: Transform } | null>(null);
+  const [keyboardActiveNodeId, setKeyboardActiveNodeId] = useState<string | null>(selectedId);
   const [panning, setPanning] = useState(false);
   const panRef = useRef<{ pointerId: number; x: number; y: number; originX: number; originY: number } | null>(null);
 
@@ -113,7 +113,7 @@ export function AtlasGraph({
     }),
     [dimensions.height, dimensions.width, edges, graphVersion, layout, nodes, selectedId],
   );
-  const { positions, stable } = useAtlasLayout(layoutOptions);
+  const { key: layoutKey, positions, stable } = useAtlasLayout(layoutOptions);
   const selectedNeighbors = useMemo(() => {
     const ids = new Set<string>();
     if (!selectedId) return ids;
@@ -128,15 +128,14 @@ export function AtlasGraph({
     () => [...nodes].sort((left, right) => right.connection_count - left.connection_count || left.label.localeCompare(right.label)),
     [nodes],
   );
-
-  useEffect(() => {
-    if (selectedId) setActiveNodeId(selectedId);
-    else if (orderedNodes.length > 0 && !activeNodeId) setActiveNodeId(orderedNodes[0]!.id);
-  }, [activeNodeId, orderedNodes, selectedId]);
-
-  const fitGraph = useCallback(() => {
+  const activeNodeId = selectedId
+    ?? (keyboardActiveNodeId && nodes.some((node) => node.id === keyboardActiveNodeId)
+      ? keyboardActiveNodeId
+      : orderedNodes[0]?.id)
+    ?? null;
+  const fittedTransform = useMemo<Transform>(() => {
     const values = Object.values(positions);
-    if (values.length === 0) return;
+    if (values.length === 0) return { x: 0, y: 0, scale: 1 };
     const xs = values.map((position) => position.x);
     const ys = values.map((position) => position.y);
     const minX = Math.min(...xs);
@@ -150,16 +149,24 @@ export function AtlasGraph({
       1.45,
       Math.max(0.35, Math.min((dimensions.width - padding * 2) / width, (dimensions.height - padding * 2) / height)),
     );
-    setTransform({
+    return {
       scale,
       x: dimensions.width / 2 - ((minX + maxX) / 2) * scale,
       y: dimensions.height / 2 - ((minY + maxY) / 2) * scale,
-    });
+    };
   }, [dimensions.height, dimensions.width, positions]);
-
-  useEffect(() => {
-    if (stable) fitGraph();
-  }, [fitGraph, graphVersion, layout, stable]);
+  const transform = manualTransform?.key === layoutKey ? manualTransform.value : fittedTransform;
+  const setTransform = useCallback(
+    (update: Transform | ((current: Transform) => Transform)) => {
+      const current = manualTransform?.key === layoutKey ? manualTransform.value : fittedTransform;
+      const value = typeof update === "function" ? update(current) : update;
+      setManualTransform({ key: layoutKey, value });
+    },
+    [fittedTransform, layoutKey, manualTransform],
+  );
+  const fitGraph = useCallback(() => {
+    setManualTransform({ key: layoutKey, value: fittedTransform });
+  }, [fittedTransform, layoutKey]);
 
   const zoomAt = useCallback((clientX: number, clientY: number, factor: number) => {
     const bounds = svgRef.current?.getBoundingClientRect();
@@ -176,7 +183,7 @@ export function AtlasGraph({
         y: pointerY - worldY * nextScale,
       };
     });
-  }, []);
+  }, [setTransform]);
 
   function handleWheel(event: WheelEvent<SVGSVGElement>) {
     event.preventDefault();
@@ -226,7 +233,7 @@ export function AtlasGraph({
     const nextIndex = (currentIndex + direction + orderedNodes.length) % orderedNodes.length;
     const nextNode = orderedNodes[nextIndex];
     if (!nextNode) return;
-    setActiveNodeId(nextNode.id);
+    setKeyboardActiveNodeId(nextNode.id);
     requestAnimationFrame(() => {
       svgRef.current?.querySelector<SVGGElement>(`[data-node-id="${CSS.escape(nextNode.id)}"]`)?.focus();
     });
@@ -308,7 +315,7 @@ export function AtlasGraph({
                 opacity={dimmed ? 0.16 : 1}
                 onClick={(event) => {
                   event.stopPropagation();
-                  setActiveNodeId(node.id);
+                  setKeyboardActiveNodeId(node.id);
                   onSelect(node.id);
                 }}
                 onKeyDown={(event) => handleNodeKeyboard(event, node.id)}
@@ -344,7 +351,10 @@ export function AtlasGraph({
           type="button"
           className={styles.iconButton}
           aria-label="Zoom in"
-          onClick={() => zoomAt(dimensions.width / 2, dimensions.height / 2, 1.18)}
+          onClick={() => {
+            const bounds = svgRef.current?.getBoundingClientRect();
+            if (bounds) zoomAt(bounds.left + bounds.width / 2, bounds.top + bounds.height / 2, 1.18);
+          }}
         >
           <Plus className="h-4 w-4" />
         </button>
@@ -352,7 +362,10 @@ export function AtlasGraph({
           type="button"
           className={styles.iconButton}
           aria-label="Zoom out"
-          onClick={() => zoomAt(dimensions.width / 2, dimensions.height / 2, 1 / 1.18)}
+          onClick={() => {
+            const bounds = svgRef.current?.getBoundingClientRect();
+            if (bounds) zoomAt(bounds.left + bounds.width / 2, bounds.top + bounds.height / 2, 1 / 1.18);
+          }}
         >
           <Minus className="h-4 w-4" />
         </button>

--- a/frontend/features/intelligence-atlas/atlas-index-sheet.tsx
+++ b/frontend/features/intelligence-atlas/atlas-index-sheet.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ArrowDownAZ, Loader2, Search } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+import { fetchAtlasIndex } from "./lib/atlas-api";
+import type { AtlasEntityType, AtlasNode } from "./lib/atlas-schema";
+import styles from "./atlas.module.css";
+
+interface AtlasIndexSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entityTypes: AtlasEntityType[];
+  country: string[];
+  funding: string[];
+  bias: string[];
+  onSelect: (nodeId: string) => void;
+}
+
+const TYPE_TABS: Array<{ value: "all" | AtlasEntityType; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "source", label: "Sources" },
+  { value: "organization", label: "Organizations" },
+  { value: "reporter", label: "Reporters" },
+];
+
+export function AtlasIndexSheet({
+  open,
+  onOpenChange,
+  entityTypes,
+  country,
+  funding,
+  bias,
+  onSelect,
+}: AtlasIndexSheetProps) {
+  const [type, setType] = useState<"all" | AtlasEntityType>("all");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState("name");
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const effectiveTypes = type === "all" ? entityTypes : [type];
+
+  const indexQuery = useInfiniteQuery({
+    queryKey: ["atlas", "index", effectiveTypes, query, country, funding, bias, sort],
+    queryFn: ({ pageParam, signal }) =>
+      fetchAtlasIndex(
+        {
+          entityTypes: effectiveTypes,
+          q: query || undefined,
+          country,
+          funding,
+          bias,
+          sort,
+          cursor: pageParam,
+          limit: 80,
+        },
+        signal,
+      ),
+    initialPageParam: null as string | null,
+    getNextPageParam: (page) => page.next_cursor ?? undefined,
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const items = useMemo(() => indexQuery.data?.pages.flatMap((page) => page.items) ?? [], [indexQuery.data]);
+  const total = indexQuery.data?.pages[0]?.total ?? 0;
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => viewportRef.current,
+    estimateSize: () => 66,
+    overscan: 8,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const virtualItems = virtualizer.getVirtualItems();
+    const last = virtualItems[virtualItems.length - 1];
+    if (!last || last.index < items.length - 8 || !indexQuery.hasNextPage || indexQuery.isFetchingNextPage) return;
+    void indexQuery.fetchNextPage();
+  }, [indexQuery, items.length, open, virtualizer]);
+
+  function choose(node: AtlasNode) {
+    onSelect(node.id);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="top-auto bottom-0 left-1/2 flex max-h-[82vh] w-[min(1120px,calc(100%-1rem))] max-w-none translate-y-0 flex-col gap-0 rounded-b-none border-white/10 bg-[#0d0f0c]/[0.98] p-0 text-[#f0ede4] shadow-2xl">
+        <DialogHeader className="border-b border-white/10 p-5 pr-14">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <DialogTitle className="font-serif text-3xl font-normal">Entity index</DialogTitle>
+              <DialogDescription className="mt-1 text-[#77736a]">
+                {total.toLocaleString()} matching records. Results are server-filtered and rendered virtually.
+              </DialogDescription>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="relative min-w-[230px] flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#77736a]" />
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search the entity index"
+                  aria-label="Search the entity index"
+                  className="border-white/10 bg-black/20 pl-9"
+                />
+              </div>
+              <label className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/20 px-3">
+                <ArrowDownAZ className="h-4 w-4 text-[#77736a]" />
+                <select
+                  value={sort}
+                  onChange={(event) => setSort(event.target.value)}
+                  className="h-10 bg-transparent text-sm text-[#c9c3b6] outline-none"
+                  aria-label="Sort entity index"
+                >
+                  <option value="name">Name</option>
+                  <option value="most_connected">Most connected</option>
+                  <option value="most_articles">Most articles</option>
+                  <option value="recently_indexed">Recently indexed</option>
+                  <option value="lowest_confidence">Lowest confidence</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div className="mt-4 flex gap-2 overflow-x-auto">
+            {TYPE_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                className={styles.pillButton}
+                data-active={type === tab.value}
+                onClick={() => setType(tab.value)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </DialogHeader>
+
+        <div ref={viewportRef} className={styles.indexViewport}>
+          {indexQuery.isLoading ? (
+            <div className={styles.emptyState}>
+              <Loader2 className="h-6 w-6 animate-spin text-[#d7b35f]" aria-label="Loading entity index" />
+            </div>
+          ) : indexQuery.error instanceof Error ? (
+            <div className={styles.emptyState}>
+              <div>
+                <div className={styles.brandTitle}>Index unavailable</div>
+                <p className={styles.contextCopy}>{indexQuery.error.message}</p>
+              </div>
+            </div>
+          ) : items.length === 0 ? (
+            <div className={styles.emptyState}>No entity records match the current index filters.</div>
+          ) : (
+            <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+              {virtualizer.getVirtualItems().map((row) => {
+                const node = items[row.index];
+                if (!node) return null;
+                return (
+                  <button
+                    key={node.id}
+                    type="button"
+                    className={styles.indexCard}
+                    style={{ height: row.size, transform: `translateY(${row.start}px)` }}
+                    onClick={() => choose(node)}
+                  >
+                    <span className={styles.entityMark} data-type={node.entity_type} aria-hidden="true">
+                      {node.entity_type.slice(0, 2).toUpperCase()}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm text-[#f0ede4]">{node.label}</span>
+                      <span className="mt-1 block truncate font-mono text-[9px] uppercase tracking-[0.13em] text-[#77736a]">
+                        {node.subtitle || node.entity_type}
+                      </span>
+                    </span>
+                    <span className="text-xs text-[#c9c3b6]">{node.country_code || "—"}</span>
+                    <span className="text-xs text-[#c9c3b6]">{node.funding_type || "—"}</span>
+                    <span className="text-xs text-[#c9c3b6]">{node.connection_count} links</span>
+                    <span className={styles.confidence} data-tier={node.confidence_tier ?? "unresolved"}>
+                      {node.confidence_tier || "unresolved"}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        {indexQuery.isFetchingNextPage ? (
+          <div className="flex items-center justify-center gap-2 border-t border-white/10 p-3 text-xs text-[#77736a]">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading more records
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas-index-sheet.tsx
+++ b/frontend/features/intelligence-atlas/atlas-index-sheet.tsx
@@ -72,22 +72,31 @@ export function AtlasIndexSheet({
     staleTime: 60_000,
   });
 
-  const items = useMemo(() => indexQuery.data?.pages.flatMap((page) => page.items) ?? [], [indexQuery.data]);
-  const total = indexQuery.data?.pages[0]?.total ?? 0;
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = indexQuery;
+  const items = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);
+  const total = data?.pages[0]?.total ?? 0;
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => viewportRef.current,
     estimateSize: () => 66,
     overscan: 8,
   });
+  const { getTotalSize, getVirtualItems } = virtualizer;
 
   useEffect(() => {
     if (!open) return;
-    const virtualItems = virtualizer.getVirtualItems();
+    const virtualItems = getVirtualItems();
     const last = virtualItems[virtualItems.length - 1];
-    if (!last || last.index < items.length - 8 || !indexQuery.hasNextPage || indexQuery.isFetchingNextPage) return;
-    void indexQuery.fetchNextPage();
-  }, [indexQuery, items.length, open, virtualizer]);
+    if (!last || last.index < items.length - 8 || !hasNextPage || isFetchingNextPage) return;
+    void fetchNextPage();
+  }, [fetchNextPage, getVirtualItems, hasNextPage, isFetchingNextPage, items.length, open]);
 
   function choose(node: AtlasNode) {
     onSelect(node.id);
@@ -149,22 +158,22 @@ export function AtlasIndexSheet({
         </DialogHeader>
 
         <div ref={viewportRef} className={styles.indexViewport}>
-          {indexQuery.isLoading ? (
+          {isLoading ? (
             <div className={styles.emptyState}>
               <Loader2 className="h-6 w-6 animate-spin text-[#d7b35f]" aria-label="Loading entity index" />
             </div>
-          ) : indexQuery.error instanceof Error ? (
+          ) : error instanceof Error ? (
             <div className={styles.emptyState}>
               <div>
                 <div className={styles.brandTitle}>Index unavailable</div>
-                <p className={styles.contextCopy}>{indexQuery.error.message}</p>
+                <p className={styles.contextCopy}>{error.message}</p>
               </div>
             </div>
           ) : items.length === 0 ? (
             <div className={styles.emptyState}>No entity records match the current index filters.</div>
           ) : (
-            <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
-              {virtualizer.getVirtualItems().map((row) => {
+            <div style={{ height: getTotalSize(), position: "relative" }}>
+              {getVirtualItems().map((row) => {
                 const node = items[row.index];
                 if (!node) return null;
                 return (
@@ -196,7 +205,7 @@ export function AtlasIndexSheet({
             </div>
           )}
         </div>
-        {indexQuery.isFetchingNextPage ? (
+        {isFetchingNextPage ? (
           <div className="flex items-center justify-center gap-2 border-t border-white/10 p-3 text-xs text-[#77736a]">
             <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading more records
           </div>

--- a/frontend/features/intelligence-atlas/atlas-inspector.tsx
+++ b/frontend/features/intelligence-atlas/atlas-inspector.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, Clock3, ExternalLink, Network, ShieldCheck } from "lucide-react";
+
+import type { AtlasEntityRecord } from "./lib/atlas-schema";
+import styles from "./atlas.module.css";
+
+interface AtlasInspectorProps {
+  record: AtlasEntityRecord | undefined;
+  loading: boolean;
+  error: Error | null;
+  onSelectConnection: (entityId: string) => void;
+}
+
+function humanize(value: string): string {
+  return value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function displayValue(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const simpleValues = value.filter((item) => ["string", "number", "boolean"].includes(typeof item));
+    if (simpleValues.length === value.length) return simpleValues.join(", ");
+    return value.length > 0 ? `${value.length} records` : null;
+  }
+  if (typeof value === "object") return `${Object.keys(value as Record<string, unknown>).length} fields`;
+  return null;
+}
+
+function dateLabel(value?: string | null): string {
+  if (!value) return "Not recorded";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not recorded";
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(date);
+}
+
+export function AtlasInspector({ record, loading, error, onSelectConnection }: AtlasInspectorProps) {
+  if (loading) {
+    return (
+      <div className={styles.inspector} aria-busy="true">
+        <div className={styles.inspectorHeader}>
+          <div className="h-3 w-28 animate-pulse rounded bg-white/10" />
+          <div className="mt-4 h-9 w-64 animate-pulse rounded bg-white/10" />
+        </div>
+        <div className={styles.inspectorBody}>
+          <div className="h-32 animate-pulse rounded-2xl bg-white/[0.05]" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.emptyState}>
+        <div>
+          <div className={styles.brandTitle}>Record unavailable</div>
+          <p className={styles.contextCopy}>{error.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div className={styles.emptyState}>
+        <div>
+          <div className={styles.brandTitle}>Select an entity</div>
+          <p className={styles.contextCopy}>Choose a source, organization, or reporter to inspect its evidence and connections.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const details = Object.entries(record.details)
+    .map(([key, value]) => [key, displayValue(value)] as const)
+    .filter((entry): entry is readonly [string, string] => Boolean(entry[1]))
+    .slice(0, 18);
+
+  return (
+    <div className={styles.inspector}>
+      <header className={styles.inspectorHeader}>
+        <div className="flex items-start gap-3">
+          <span className={styles.entityMark} data-type={record.entity_type} aria-hidden="true">
+            {record.entity_type.slice(0, 2).toUpperCase()}
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className={styles.brandEyebrow}>{record.entity_type} record</div>
+            <h2 className="mt-2 font-serif text-3xl leading-none text-[#f0ede4]">{record.label}</h2>
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-[#c9c3b6]">
+              {record.subtitle ? <span>{record.subtitle}</span> : null}
+              {record.country_code ? <span>{record.country_code}</span> : null}
+              <span className={styles.confidence} data-tier={record.confidence_tier ?? "unresolved"}>
+                {humanize(record.confidence_tier ?? "unresolved")}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-2 gap-2">
+          <div className={styles.detailCard}>
+            <div className={styles.microLabel}>Last verified</div>
+            <div className={styles.detailValue}>{dateLabel(record.last_verified_at)}</div>
+          </div>
+          <div className={styles.detailCard}>
+            <div className={styles.microLabel}>Evidence</div>
+            <div className={styles.detailValue}>{record.evidence.length} cited records</div>
+          </div>
+        </div>
+        {record.profile_path ? (
+          <Link href={record.profile_path} className="mt-4 inline-flex items-center gap-2 text-sm text-[#d7b35f] hover:text-[#f0ede4]">
+            Open full profile <ArrowUpRight className="h-4 w-4" />
+          </Link>
+        ) : null}
+      </header>
+
+      <div className={styles.inspectorBody}>
+        <section>
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-[#d7b35f]" />
+            <h3 className={styles.controlLabel}>Identity and context</h3>
+          </div>
+          <div className={styles.detailGrid}>
+            {details.length > 0 ? (
+              details.map(([key, value]) => (
+                <div key={key} className={styles.detailCard}>
+                  <div className={styles.microLabel}>{humanize(key)}</div>
+                  <div className={styles.detailValue}>{value}</div>
+                </div>
+              ))
+            ) : (
+              <div className={`${styles.detailCard} col-span-2`}>
+                <div className={styles.detailValue}>No structured profile fields are indexed for this entity yet.</div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className={styles.inspectorSection}>
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2">
+              <Network className="h-4 w-4 text-[#88a9ff]" />
+              <h3 className={styles.controlLabel}>Connections</h3>
+            </div>
+            <span className="font-mono text-[10px] text-[#77736a]">{record.connections.length}</span>
+          </div>
+          <div className="mt-2">
+            {record.connections.length > 0 ? (
+              record.connections.slice(0, 40).map(({ edge, entity }) => (
+                <button
+                  key={edge.id}
+                  type="button"
+                  className={styles.connectionButton}
+                  onClick={() => onSelectConnection(entity.id)}
+                >
+                  <span>
+                    <span className="block text-sm text-[#f0ede4]">{entity.label}</span>
+                    <span className="mt-1 block font-mono text-[9px] uppercase tracking-[0.14em] text-[#77736a]">
+                      {humanize(edge.relation_type)} · {edge.direction}
+                    </span>
+                  </span>
+                  <span className="text-right">
+                    <span className={styles.confidence} data-tier={edge.confidence_tier ?? "unresolved"}>
+                      {edge.confidence != null ? `${Math.round(edge.confidence * 100)}%` : "Unrated"}
+                    </span>
+                    <span className="mt-1 block text-[10px] text-[#77736a]">{edge.evidence_count} evidence</span>
+                  </span>
+                </button>
+              ))
+            ) : (
+              <p className={styles.contextCopy}>This entity has no relationships in the current bounded graph.</p>
+            )}
+          </div>
+        </section>
+
+        <section className={styles.inspectorSection}>
+          <div className="flex items-center gap-2">
+            <Clock3 className="h-4 w-4 text-[#62e3b0]" />
+            <h3 className={styles.controlLabel}>Evidence trail</h3>
+          </div>
+          <div className="mt-2">
+            {record.evidence.length > 0 ? (
+              record.evidence.map((evidence) => (
+                <article key={evidence.id} className={styles.evidenceCard}>
+                  <div>
+                    <div className="text-sm text-[#f0ede4]">{evidence.source_name || humanize(evidence.source_type)}</div>
+                    {evidence.excerpt ? <p className="mt-1 text-xs leading-relaxed text-[#c9c3b6]">{evidence.excerpt}</p> : null}
+                    <div className="mt-2 font-mono text-[9px] uppercase tracking-[0.13em] text-[#77736a]">
+                      Retrieved {dateLabel(evidence.retrieved_at)}
+                    </div>
+                  </div>
+                  {evidence.source_url ? (
+                    <a
+                      href={evidence.source_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`Open evidence from ${evidence.source_name || evidence.source_type}`}
+                      className="text-[#d7b35f] hover:text-[#f0ede4]"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  ) : null}
+                </article>
+              ))
+            ) : (
+              <p className={styles.contextCopy}>No evidence rows are attached to the visible relationships. The confidence label remains explicit rather than implying certainty.</p>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas-operations-sheet.tsx
+++ b/frontend/features/intelligence-atlas/atlas-operations-sheet.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  fetchCacheStatus,
+  fetchSourceStats,
+  fetchWikiIndexStatus,
+  fetchWikiSource,
+  type WikiSourceProfile,
+} from "@/lib/api";
+import { SourceIntelligenceOperations } from "@/app/wiki/ownership/source-intelligence-operations";
+import {
+  WORKSPACE_TABS,
+  type WorkspaceTab,
+} from "@/app/wiki/ownership/source-intelligence-support";
+
+interface AtlasOperationsSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeTab: WorkspaceTab;
+  onTabChange: (tab: WorkspaceTab) => void;
+  selectedSourceName: string | null;
+}
+
+export function AtlasOperationsSheet({
+  open,
+  onOpenChange,
+  activeTab,
+  onTabChange,
+  selectedSourceName,
+}: AtlasOperationsSheetProps) {
+  const queryClient = useQueryClient();
+  const sourceStatsQuery = useQuery({
+    queryKey: ["debug-source-stats-summary"],
+    queryFn: fetchSourceStats,
+    enabled: open,
+    retry: 1,
+  });
+  const cacheStatusQuery = useQuery({
+    queryKey: ["debug-cache-status-summary"],
+    queryFn: fetchCacheStatus,
+    enabled: open,
+    retry: 1,
+  });
+  const indexStatusQuery = useQuery({
+    queryKey: ["wiki-index-status"],
+    queryFn: fetchWikiIndexStatus,
+    enabled: open,
+    retry: 1,
+  });
+  const sourceProfileQuery = useQuery<WikiSourceProfile>({
+    queryKey: ["wiki-source-profile", selectedSourceName],
+    queryFn: () => fetchWikiSource(selectedSourceName ?? ""),
+    enabled: open && Boolean(selectedSourceName),
+    retry: 1,
+  });
+
+  const tabs = useMemo(() => [...WORKSPACE_TABS], []);
+
+  async function refreshAll() {
+    await Promise.allSettled([
+      sourceStatsQuery.refetch(),
+      cacheStatusQuery.refetch(),
+      indexStatusQuery.refetch(),
+      selectedSourceName ? sourceProfileQuery.refetch() : Promise.resolve(null),
+    ]);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["atlas"] }),
+      queryClient.invalidateQueries({ queryKey: ["wiki-source-profile"] }),
+    ]);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="top-auto bottom-0 left-1/2 flex h-[min(82vh,880px)] w-[min(1320px,calc(100%-1rem))] max-w-none translate-y-0 flex-col gap-0 rounded-b-none border-white/10 bg-[#0d0f0c]/[0.99] p-0 text-[#f0ede4] shadow-2xl">
+        <DialogHeader className="border-b border-white/10 p-5 pr-14">
+          <DialogTitle className="font-serif text-3xl font-normal">Atlas operations</DialogTitle>
+          <DialogDescription className="mt-1 text-[#77736a]">
+            Inspect ingestion, parser, model, storage, and error state without shrinking the investigation graph.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 p-4">
+          <SourceIntelligenceOperations
+            activeTab={activeTab}
+            onTabChange={onTabChange}
+            tabs={tabs}
+            sourceStats={sourceStatsQuery.data ?? []}
+            cacheStatus={cacheStatusQuery.data ?? null}
+            wikiIndexStatus={indexStatusQuery.data}
+            selectedSourceName={selectedSourceName}
+            selectedSourceProfile={sourceProfileQuery.data ?? null}
+            onRefreshAll={() => {
+              void refreshAll();
+            }}
+            onSourceProfileRefresh={async () => {
+              if (!selectedSourceName) return;
+              await sourceProfileQuery.refetch();
+            }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas-stage-shell.tsx
+++ b/frontend/features/intelligence-atlas/atlas-stage-shell.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Activity, AlertTriangle, BookOpen, Layers3 } from "lucide-react";
+
+import { AtlasGraph } from "./atlas-graph";
+import type { AtlasLayoutMode, AtlasQueryState } from "./lib/atlas-query-state";
+import type {
+  AtlasEntityType,
+  AtlasGraphResponse,
+  AtlasNode,
+  AtlasRelationType,
+} from "./lib/atlas-schema";
+import styles from "./atlas.module.css";
+
+type AtlasGraphStats = AtlasGraphResponse["stats"];
+
+const ENTITY_OPTIONS: Array<{ value: AtlasEntityType; label: string }> = [
+  { value: "source", label: "Sources" },
+  { value: "organization", label: "Organizations" },
+  { value: "reporter", label: "Reporters" },
+];
+const RELATION_OPTIONS: Array<{ value: AtlasRelationType; label: string }> = [
+  { value: "ownership", label: "Ownership" },
+  { value: "publishes", label: "Publishing" },
+  { value: "parent_org", label: "Parent" },
+  { value: "part_of", label: "Part of" },
+  { value: "employed_by", label: "Employment" },
+  { value: "current_outlet", label: "Current outlet" },
+  { value: "coauthor", label: "Coauthor" },
+  { value: "shared_outlet", label: "Shared outlet" },
+];
+const LAYOUT_OPTIONS: Array<{ value: AtlasLayoutMode; label: string }> = [
+  { value: "clustered", label: "Clustered" },
+  { value: "ownership", label: "Ownership" },
+  { value: "geography", label: "Geography" },
+  { value: "radial", label: "Radial" },
+];
+
+function toggleValue<T extends string>(values: T[], value: T): T[] {
+  return values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
+}
+function humanize(value: string): string {
+  return value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+interface AtlasStageShellProps {
+  state: AtlasQueryState;
+  graph?: AtlasGraphResponse;
+  graphVersion: string;
+  loading: boolean;
+  fetching: boolean;
+  error: Error | null;
+  selectedNode: AtlasNode | null;
+  dockNodes: AtlasNode[];
+  totalStats?: AtlasGraphStats;
+  ownershipCoverage: number;
+  onStateChange: (patch: Partial<AtlasQueryState>) => void;
+  onSelect: (nodeId: string, entityType?: AtlasEntityType) => void;
+  onOpenIndex: () => void;
+  onOpenOperations: () => void;
+  onRetry: () => void;
+}
+
+export function AtlasStageShell({
+  state,
+  graph,
+  graphVersion,
+  loading,
+  error,
+  selectedNode,
+  dockNodes,
+  totalStats,
+  ownershipCoverage,
+  onStateChange,
+  onSelect,
+  onOpenIndex,
+  onOpenOperations,
+  onRetry,
+}: AtlasStageShellProps) {
+  const nodes = graph?.nodes ?? [];
+  const edges = graph?.edges ?? [];
+  const currentStats = graph?.stats;
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  return (
+    <>
+      <div className={styles.stage}>
+        <section className={styles.contextPanel} aria-label="Atlas context and coverage">
+          <div className={styles.brandEyebrow}>{selectedNode ? `${humanize(selectedNode.entity_type)} selected` : "Traceable media context"}</div>
+          <h2 className={styles.contextTitle}>{selectedNode?.label || "Follow publication, ownership, reporter, and evidence relationships."}</h2>
+          <p className={styles.contextCopy}>
+            {selectedNode
+              ? "Direct connections remain visible while the inspector exposes confidence, provenance, verification dates, and unresolved claims."
+              : "Every visible relationship is typed. Inferred and evidence-backed links remain distinguishable, and bounded results declare truncation."}
+          </p>
+          <div className={styles.metrics}>
+            <Metric label="Sources" value={currentStats?.visible_sources ?? totalStats?.total_sources ?? 0} />
+            <Metric label="Organizations" value={currentStats?.visible_organizations ?? totalStats?.total_organizations ?? 0} />
+            <Metric label="Reporters" value={currentStats?.visible_reporters ?? totalStats?.total_reporters ?? 0} />
+            <Metric label="Relationships" value={currentStats?.visible_relationships ?? 0} />
+            <Metric label="Ownership coverage" value={`${ownershipCoverage}%`} />
+          </div>
+        </section>
+
+        <div className={styles.toolbar} aria-label="Graph filters and layout">
+          <div className={styles.toolbarGroup}>
+            <span className={`${styles.controlLabel} px-2`}>Entities</span>
+            {ENTITY_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={styles.pillButton}
+                data-active={state.entities.includes(option.value)}
+                onClick={() => {
+                  const values = toggleValue(state.entities, option.value);
+                  if (values.length > 0) onStateChange({ entities: values, selected: values.includes(selectedNode?.entity_type ?? "source") ? state.selected : null });
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <div className={styles.toolbarGroup}>
+            <span className={`${styles.controlLabel} px-2`}>Relations</span>
+            {RELATION_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={styles.pillButton}
+                data-active={state.relations.includes(option.value)}
+                onClick={() => {
+                  const values = toggleValue(state.relations, option.value);
+                  if (values.length > 0) onStateChange({ relations: values });
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <label className={styles.toolbarGroup}>
+            <Layers3 className="ml-2 h-3.5 w-3.5 text-[#77736a]" />
+            <select
+              value={state.layout}
+              onChange={(event) => onStateChange({ layout: event.target.value as AtlasLayoutMode })}
+              className="h-8 bg-transparent px-2 text-xs text-[#c9c3b6] outline-none"
+              aria-label="Graph layout"
+            >
+              {LAYOUT_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+        </div>
+
+        <AtlasGraph
+          nodes={nodes}
+          edges={edges}
+          graphVersion={graphVersion}
+          layout={state.layout}
+          selectedId={state.selected}
+          focus={state.focus}
+          loading={loading}
+          onSelect={(nodeId) => onSelect(nodeId, nodesById.get(nodeId)?.entity_type)}
+        />
+
+        {graph?.truncated ? (
+          <div className={styles.warningBanner} role="status">
+            <span className="flex items-center gap-2 text-sm">
+              <AlertTriangle className="h-4 w-4 text-[#d7b35f]" />
+              This is a bounded graph. Hidden entities or edges reached the {graph.truncation_reason?.replaceAll("_", " ")}.
+            </span>
+            <button type="button" className={styles.pillButton} onClick={onOpenIndex}>Browse full index</button>
+          </div>
+        ) : null}
+        {error ? (
+          <div className={styles.errorBanner} role="alert">
+            <span>{error.message}</span>
+            <button type="button" className={styles.pillButton} onClick={onRetry}>Retry</button>
+          </div>
+        ) : null}
+      </div>
+
+      <footer className={styles.dock}>
+        <div>
+          <div className={styles.brandEyebrow}>Record dock</div>
+          <div className="mt-1 text-xs text-[#77736a]">Selected, recent, and high-salience visible entities</div>
+        </div>
+        <div className={styles.dockList}>
+          {dockNodes.map((node) => (
+            <button key={node.id} type="button" className={styles.recordCard} data-selected={state.selected === node.id} onClick={() => onSelect(node.id, node.entity_type)}>
+              <span className={styles.entityMark} data-type={node.entity_type} aria-hidden="true">{node.entity_type.slice(0, 2).toUpperCase()}</span>
+              <span className="min-w-0">
+                <span className="block truncate text-sm text-[#f0ede4]">{node.label}</span>
+                <span className="mt-1 block truncate font-mono text-[9px] uppercase tracking-[0.13em] text-[#77736a]">
+                  {node.connection_count} links · {node.status || node.confidence_tier || "unresolved"}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <button type="button" className={styles.actionButton} onClick={onOpenIndex}><BookOpen className="h-4 w-4" /> <span>Browse all</span></button>
+          <button type="button" className={styles.actionButton} onClick={onOpenOperations}><Activity className="h-4 w-4" /> <span>Operations</span></button>
+        </div>
+      </footer>
+    </>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className={styles.metric}>
+      <div className={styles.microLabel}>{label}</div>
+      <div className={styles.metricValue}>{typeof value === "number" ? value.toLocaleString() : value}</div>
+    </div>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas-topbar.tsx
+++ b/frontend/features/intelligence-atlas/atlas-topbar.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import {
+  Copy,
+  Download,
+  Focus,
+  Loader2,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import type {
+  ChangeEvent,
+  KeyboardEvent,
+  RefObject,
+} from "react";
+
+import type { AtlasSearchItem } from "./lib/atlas-schema";
+import styles from "./atlas.module.css";
+
+function humanize(value: string): string {
+  return value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function dateDistance(value?: string | null): string {
+  if (!value) return "Not indexed";
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "Not indexed";
+  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h ago`;
+  return `${Math.round(seconds / 86400)}d ago`;
+}
+
+interface AtlasTopbarProps {
+  inputRef: RefObject<HTMLInputElement | null>;
+  searchText: string;
+  searchOpen: boolean;
+  searchItems: AtlasSearchItem[];
+  activeSearchIndex: number;
+  searching: boolean;
+  focus: boolean;
+  exporting: boolean;
+  refreshing: boolean;
+  indexing: boolean;
+  lastIndexed?: string | null;
+  onSearchChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onSearchFocus: () => void;
+  onSearchKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  onSearchHover: (index: number) => void;
+  onChooseSearchResult: (item: AtlasSearchItem) => void;
+  onToggleFocus: () => void;
+  onCopy: () => void;
+  onExport: () => void;
+  onRefresh: () => void;
+}
+
+export function AtlasTopbar({
+  inputRef,
+  searchText,
+  searchOpen,
+  searchItems,
+  activeSearchIndex,
+  searching,
+  focus,
+  exporting,
+  refreshing,
+  indexing,
+  lastIndexed,
+  onSearchChange,
+  onSearchFocus,
+  onSearchKeyDown,
+  onSearchHover,
+  onChooseSearchResult,
+  onToggleFocus,
+  onCopy,
+  onExport,
+  onRefresh,
+}: AtlasTopbarProps) {
+  return (
+    <header className={styles.topbar}>
+      <div>
+        <div className={styles.brandEyebrow}>SCOOP / Media accountability</div>
+        <h1 className={styles.brandTitle}>Intelligence Atlas</h1>
+      </div>
+
+      <div className={styles.searchWrap}>
+        <Search className={styles.searchIcon} />
+        <input
+          ref={inputRef}
+          value={searchText}
+          onChange={onSearchChange}
+          onFocus={onSearchFocus}
+          onKeyDown={onSearchKeyDown}
+          className={styles.searchInput}
+          placeholder="Search sources, owners, reporters, countries, or IDs"
+          aria-label="Search Intelligence Atlas"
+          aria-expanded={searchOpen}
+          aria-controls="atlas-search-results"
+          role="combobox"
+          autoComplete="off"
+        />
+        <span className={styles.searchShortcut}>⌘K</span>
+        {searchOpen && searchText.trim() ? (
+          <div id="atlas-search-results" className={styles.searchResults} role="listbox">
+            {searching ? (
+              <div className="flex items-center gap-2 p-4 text-sm text-[#77736a]">
+                <Loader2 className="h-4 w-4 animate-spin" /> Searching indexed entities
+              </div>
+            ) : searchItems.length > 0 ? (
+              (["source", "organization", "reporter"] as const).map((type) => {
+                const items = searchItems.filter((item) => item.entity_type === type);
+                if (items.length === 0) return null;
+                return (
+                  <div key={type} className={styles.searchGroup}>
+                    <div className={`${styles.microLabel} px-2 pb-2`}>{humanize(type)}s</div>
+                    {items.map((item) => {
+                      const index = searchItems.findIndex((candidate) => candidate.id === item.id);
+                      return (
+                        <button
+                          key={item.id}
+                          type="button"
+                          role="option"
+                          aria-selected={index === activeSearchIndex}
+                          className={styles.searchResult}
+                          data-active={index === activeSearchIndex}
+                          onMouseEnter={() => onSearchHover(index)}
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={() => onChooseSearchResult(item)}
+                        >
+                          <span className={styles.entityMark} data-type={item.entity_type} aria-hidden="true">
+                            {item.entity_type.slice(0, 2).toUpperCase()}
+                          </span>
+                          <span className="min-w-0">
+                            <span className="block truncate text-sm text-[#f0ede4]">{item.label}</span>
+                            <span className="mt-1 block truncate text-xs text-[#77736a]">
+                              {item.subtitle || item.country_code || item.id}
+                            </span>
+                          </span>
+                          <span className={styles.confidence} data-tier={item.confidence_tier ?? "unresolved"}>
+                            {item.confidence_tier || "unresolved"}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                );
+              })
+            ) : (
+              <div className="p-4 text-sm text-[#77736a]">No indexed entity matches this query.</div>
+            )}
+          </div>
+        ) : null}
+      </div>
+
+      <div className={styles.actionRow}>
+        <div className="hidden items-center gap-2 pr-2 text-[10px] font-mono uppercase tracking-[0.13em] text-[#77736a] xl:flex">
+          <span className={`h-1.5 w-1.5 rounded-full ${indexing ? "animate-pulse bg-amber-300" : "bg-emerald-300"}`} />
+          {indexing ? "Indexing" : `Indexed ${dateDistance(lastIndexed)}`}
+        </div>
+        <button type="button" className={styles.actionButton} data-active={focus} onClick={onToggleFocus}>
+          <Focus className="h-4 w-4" /> <span>Focus</span>
+        </button>
+        <button type="button" className={styles.iconButton} aria-label="Copy investigation link" onClick={onCopy}>
+          <Copy className="h-4 w-4" />
+        </button>
+        <button type="button" className={styles.actionButton} disabled={exporting} onClick={onExport}>
+          {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />} <span>Export</span>
+        </button>
+        <button type="button" className={styles.iconButton} aria-label="Refresh Atlas data" onClick={onRefresh}>
+          <RefreshCw className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/features/intelligence-atlas/atlas.module.css
+++ b/frontend/features/intelligence-atlas/atlas.module.css
@@ -1,0 +1,697 @@
+.atlas {
+  --atlas-bg: #080907;
+  --atlas-elevated: #0d0f0c;
+  --atlas-paper: #f0ede4;
+  --atlas-paper-soft: #c9c3b6;
+  --atlas-muted: #77736a;
+  --atlas-line: rgb(240 237 228 / 0.13);
+  --atlas-line-strong: rgb(240 237 228 / 0.24);
+  --atlas-accent: #d7b35f;
+  --atlas-success: #62e3b0;
+  --atlas-reporter: #88a9ff;
+  --atlas-danger: #f1635e;
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  color: var(--atlas-paper);
+  background:
+    radial-gradient(circle at 20% 0%, rgb(215 179 95 / 0.12), transparent 34rem),
+    radial-gradient(circle at 100% 100%, rgb(136 169 255 / 0.07), transparent 32rem),
+    var(--atlas-bg);
+}
+
+.atlas::before {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  opacity: 0.32;
+  background-image:
+    linear-gradient(var(--atlas-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--atlas-line) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: linear-gradient(to bottom, black, transparent 75%);
+}
+
+.shell {
+  position: relative;
+  display: flex;
+  min-height: 100vh;
+}
+
+.workspace {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  height: 100vh;
+}
+
+.topbar {
+  position: relative;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(240px, 0.7fr) minmax(320px, 1.15fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--atlas-line);
+  background: rgb(8 9 7 / 0.82);
+  backdrop-filter: blur(22px);
+}
+
+.brandEyebrow,
+.controlLabel,
+.microLabel {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--atlas-muted);
+}
+
+.brandTitle {
+  margin-top: 4px;
+  font-family: var(--font-serif);
+  font-size: clamp(1.45rem, 2.2vw, 2.2rem);
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+}
+
+.searchWrap {
+  position: relative;
+}
+
+.searchInput {
+  width: 100%;
+  min-height: 46px;
+  padding: 0 44px 0 42px;
+  border: 1px solid var(--atlas-line-strong);
+  border-radius: 999px;
+  color: var(--atlas-paper);
+  background: rgb(240 237 228 / 0.035);
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: var(--atlas-muted);
+}
+
+.searchInput:focus {
+  border-color: rgb(215 179 95 / 0.62);
+  box-shadow: 0 0 0 4px rgb(215 179 95 / 0.08);
+}
+
+.searchIcon {
+  position: absolute;
+  top: 50%;
+  left: 16px;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-50%);
+  color: var(--atlas-muted);
+}
+
+.searchShortcut {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  padding: 4px 7px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 6px;
+  transform: translateY(-50%);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--atlas-muted);
+}
+
+.searchResults {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  left: 0;
+  z-index: 50;
+  overflow: hidden;
+  border: 1px solid var(--atlas-line-strong);
+  border-radius: 18px;
+  background: rgb(13 15 12 / 0.97);
+  box-shadow: 0 24px 80px rgb(0 0 0 / 0.55);
+}
+
+.searchGroup {
+  padding: 10px;
+  border-top: 1px solid var(--atlas-line);
+}
+
+.searchGroup:first-child {
+  border-top: 0;
+}
+
+.searchResult {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 10px;
+  text-align: left;
+}
+
+.searchResult:hover,
+.searchResult[data-active="true"] {
+  background: rgb(240 237 228 / 0.07);
+}
+
+.actionRow {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.actionButton,
+.pillButton,
+.iconButton {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 999px;
+  color: var(--atlas-paper-soft);
+  background: rgb(240 237 228 / 0.025);
+  transition: 150ms ease;
+}
+
+.iconButton {
+  width: 38px;
+  padding: 0;
+}
+
+.actionButton:hover,
+.pillButton:hover,
+.iconButton:hover,
+.actionButton[data-active="true"],
+.pillButton[data-active="true"] {
+  border-color: rgb(215 179 95 / 0.48);
+  color: var(--atlas-paper);
+  background: rgb(215 179 95 / 0.08);
+}
+
+.stage {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.contextPanel {
+  position: absolute;
+  top: 22px;
+  left: 22px;
+  z-index: 8;
+  width: min(430px, calc(100% - 44px));
+  padding: 16px 18px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 18px;
+  background: rgb(8 9 7 / 0.72);
+  backdrop-filter: blur(18px);
+}
+
+.contextTitle {
+  font-family: var(--font-serif);
+  font-size: clamp(1.55rem, 2.4vw, 2.55rem);
+  line-height: 0.98;
+}
+
+.contextCopy {
+  max-width: 42rem;
+  margin-top: 9px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--atlas-paper-soft);
+}
+
+.metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.metric {
+  min-width: 86px;
+  padding: 8px 10px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 11px;
+  background: rgb(0 0 0 / 0.2);
+}
+
+.metricValue {
+  margin-top: 3px;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--atlas-paper);
+}
+
+.toolbar {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  z-index: 9;
+  display: flex;
+  max-width: min(670px, calc(100% - 44px));
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.toolbarGroup {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 999px;
+  background: rgb(8 9 7 / 0.78);
+  backdrop-filter: blur(16px);
+}
+
+.pillButton {
+  min-height: 30px;
+  padding: 0 10px;
+  border-color: transparent;
+  font-size: 11px;
+}
+
+.graphCanvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+  cursor: grab;
+}
+
+.graphCanvas[data-panning="true"] {
+  cursor: grabbing;
+}
+
+.edge {
+  fill: none;
+  stroke-width: 1.1;
+  vector-effect: non-scaling-stroke;
+}
+
+.nodeButton {
+  cursor: pointer;
+  outline: none;
+}
+
+.nodeButton:focus-visible .nodeHalo {
+  opacity: 1;
+  stroke-width: 3;
+}
+
+.nodeLabel {
+  pointer-events: none;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  paint-order: stroke;
+  stroke: rgb(8 9 7 / 0.96);
+  stroke-width: 4px;
+  stroke-linejoin: round;
+}
+
+.nodeMeta {
+  pointer-events: none;
+  font-family: var(--font-mono);
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  fill: var(--atlas-muted);
+  paint-order: stroke;
+  stroke: rgb(8 9 7 / 0.96);
+  stroke-width: 3px;
+}
+
+.graphStatus {
+  position: absolute;
+  right: 22px;
+  bottom: 92px;
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 11px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--atlas-muted);
+  background: rgb(8 9 7 / 0.76);
+}
+
+.warningBanner,
+.errorBanner {
+  position: absolute;
+  right: 22px;
+  bottom: 142px;
+  left: 22px;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgb(215 179 95 / 0.32);
+  border-radius: 14px;
+  color: var(--atlas-paper-soft);
+  background: rgb(51 40 19 / 0.88);
+  backdrop-filter: blur(16px);
+}
+
+.errorBanner {
+  border-color: rgb(241 99 94 / 0.36);
+  background: rgb(54 22 21 / 0.9);
+}
+
+.dock {
+  position: relative;
+  z-index: 16;
+  display: grid;
+  min-height: 78px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-top: 1px solid var(--atlas-line);
+  background: rgb(8 9 7 / 0.88);
+  backdrop-filter: blur(20px);
+}
+
+.dockList {
+  display: flex;
+  min-width: 0;
+  gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.dockList::-webkit-scrollbar {
+  display: none;
+}
+
+.recordCard {
+  display: grid;
+  min-width: 210px;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 13px;
+  text-align: left;
+  background: rgb(240 237 228 / 0.025);
+}
+
+.recordCard[data-selected="true"] {
+  border-color: rgb(215 179 95 / 0.46);
+  background: rgb(215 179 95 / 0.08);
+}
+
+.entityMark {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.entityMark[data-type="organization"] {
+  color: var(--atlas-accent);
+}
+
+.entityMark[data-type="source"] {
+  color: var(--atlas-paper);
+  border-radius: 8px;
+}
+
+.entityMark[data-type="reporter"] {
+  color: var(--atlas-reporter);
+  border-radius: 50% 50% 40% 40%;
+}
+
+.inspector {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.inspectorHeader {
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--atlas-line);
+}
+
+.inspectorBody {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 24px 32px;
+}
+
+.inspectorSection {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid var(--atlas-line);
+}
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.detailCard {
+  min-width: 0;
+  padding: 11px 12px;
+  border: 1px solid var(--atlas-line);
+  border-radius: 12px;
+  background: rgb(240 237 228 / 0.025);
+}
+
+.detailValue {
+  margin-top: 5px;
+  overflow-wrap: anywhere;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--atlas-paper-soft);
+}
+
+.connectionButton,
+.evidenceCard {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--atlas-line);
+  text-align: left;
+}
+
+.connectionButton:first-child,
+.evidenceCard:first-child {
+  border-top: 0;
+}
+
+.confidence {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--atlas-paper-soft);
+}
+
+.confidence::before {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  content: "";
+  background: var(--atlas-muted);
+}
+
+.confidence[data-tier="verified"]::before,
+.confidence[data-tier="strong"]::before {
+  background: var(--atlas-success);
+}
+
+.confidence[data-tier="likely"]::before {
+  background: var(--atlas-accent);
+}
+
+.confidence[data-tier="conflicting"]::before,
+.confidence[data-tier="stale"]::before {
+  background: var(--atlas-danger);
+}
+
+.indexViewport {
+  position: relative;
+  height: min(64vh, 690px);
+  overflow: auto;
+  border-top: 1px solid var(--atlas-line);
+}
+
+.indexCard {
+  position: absolute;
+  right: 0;
+  left: 0;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) repeat(3, minmax(80px, 0.45fr)) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--atlas-line);
+  text-align: left;
+}
+
+.indexCard:hover {
+  background: rgb(240 237 228 / 0.035);
+}
+
+.accessibleList {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
+.emptyState {
+  display: grid;
+  height: 100%;
+  place-items: center;
+  padding: 32px;
+  text-align: center;
+  color: var(--atlas-paper-soft);
+}
+
+@media (max-width: 1180px) {
+  .topbar {
+    grid-template-columns: minmax(190px, 0.55fr) minmax(260px, 1fr) auto;
+  }
+
+  .actionButton span {
+    display: none;
+  }
+
+  .toolbar {
+    top: auto;
+    right: 16px;
+    bottom: 86px;
+  }
+
+  .contextPanel {
+    top: 16px;
+    left: 16px;
+    max-width: 380px;
+  }
+}
+
+@media (max-width: 860px) {
+  .workspace {
+    height: 100dvh;
+  }
+
+  .topbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .searchWrap {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .actionRow .actionButton:nth-child(n + 3) {
+    display: none;
+  }
+
+  .contextPanel {
+    width: calc(100% - 24px);
+    max-width: none;
+    top: 12px;
+    left: 12px;
+    padding: 12px 14px;
+  }
+
+  .contextCopy {
+    display: none;
+  }
+
+  .metrics {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .metric {
+    min-width: 78px;
+  }
+
+  .toolbar {
+    right: 12px;
+    bottom: 76px;
+    left: 12px;
+    max-width: none;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    overflow-x: auto;
+  }
+
+  .dock {
+    min-height: 66px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 8px 12px;
+  }
+
+  .dock > :first-child {
+    display: none;
+  }
+
+  .recordCard {
+    min-width: 190px;
+  }
+
+  .indexCard {
+    grid-template-columns: 36px minmax(0, 1fr) auto;
+  }
+
+  .indexCard > :nth-child(3),
+  .indexCard > :nth-child(4),
+  .indexCard > :nth-child(5) {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .actionButton,
+  .pillButton,
+  .iconButton {
+    transition: none;
+  }
+}

--- a/frontend/features/intelligence-atlas/hooks/use-atlas-layout.ts
+++ b/frontend/features/intelligence-atlas/hooks/use-atlas-layout.ts
@@ -25,37 +25,30 @@ function topologyKey(options: UseAtlasLayoutOptions): string {
 }
 
 export function useAtlasLayout(options: UseAtlasLayoutOptions) {
-  const [positions, setPositions] = useState<Record<string, AtlasPosition>>({});
-  const [stable, setStable] = useState(false);
+  const key = topologyKey(options);
+  const cached = layoutCache.get(key);
+  const empty = options.nodes.length === 0 || options.width <= 0 || options.height <= 0;
+  const [result, setResult] = useState<{
+    key: string;
+    positions: Record<string, AtlasPosition>;
+    stable: boolean;
+  }>({ key: "", positions: {}, stable: false });
   const requestIdRef = useRef(0);
 
   useEffect(() => {
-    if (options.nodes.length === 0 || options.width <= 0 || options.height <= 0) {
-      setPositions({});
-      setStable(true);
-      return;
-    }
-
-    const key = topologyKey(options);
-    const cached = layoutCache.get(key);
-    if (cached) {
-      setPositions(cached);
-      setStable(true);
-      return;
-    }
+    if (empty || cached) return;
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
-    setStable(false);
     const worker = new Worker(new URL("../../../workers/atlas-layout.worker.ts", import.meta.url), {
       type: "module",
     });
     worker.onmessage = (event: MessageEvent<AtlasLayoutResponse>) => {
       if (event.data.requestId !== requestIdRef.current) return;
-      setPositions(event.data.positions);
-      if (event.data.type === "complete") {
+      const complete = event.data.type === "complete";
+      setResult({ key, positions: event.data.positions, stable: complete });
+      if (complete) {
         layoutCache.set(key, event.data.positions);
-        setStable(true);
         worker.terminate();
       }
     };
@@ -73,8 +66,7 @@ export function useAtlasLayout(options: UseAtlasLayoutOptions) {
           ];
         }),
       );
-      setPositions(fallback);
-      setStable(true);
+      setResult({ key, positions: fallback, stable: true });
       worker.terminate();
     };
     worker.postMessage({
@@ -102,7 +94,10 @@ export function useAtlasLayout(options: UseAtlasLayoutOptions) {
       worker.postMessage({ type: "cancel", requestId });
       worker.terminate();
     };
-  }, [options]);
+  }, [cached, empty, key, options]);
 
-  return { positions, stable };
+  if (empty) return { key, positions: {}, stable: true };
+  if (cached) return { key, positions: cached, stable: true };
+  if (result.key === key) return { key, positions: result.positions, stable: result.stable };
+  return { key, positions: {}, stable: false };
 }

--- a/frontend/features/intelligence-atlas/hooks/use-atlas-layout.ts
+++ b/frontend/features/intelligence-atlas/hooks/use-atlas-layout.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { AtlasEdge, AtlasNode } from "../lib/atlas-schema";
+import type { AtlasLayoutMode } from "../lib/atlas-query-state";
+import type { AtlasLayoutResponse, AtlasPosition } from "../lib/atlas-layout-protocol";
+
+interface UseAtlasLayoutOptions {
+  nodes: AtlasNode[];
+  edges: AtlasEdge[];
+  width: number;
+  height: number;
+  layout: AtlasLayoutMode;
+  selectedId: string | null;
+  graphVersion: string;
+}
+
+const layoutCache = new Map<string, Record<string, AtlasPosition>>();
+
+function topologyKey(options: UseAtlasLayoutOptions): string {
+  const ids = options.nodes.map((node) => node.id).sort().join("|");
+  const edges = options.edges.map((edge) => edge.id).sort().join("|");
+  return `${options.graphVersion}:${options.layout}:${Math.round(options.width)}:${Math.round(options.height)}:${ids}:${edges}`;
+}
+
+export function useAtlasLayout(options: UseAtlasLayoutOptions) {
+  const [positions, setPositions] = useState<Record<string, AtlasPosition>>({});
+  const [stable, setStable] = useState(false);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (options.nodes.length === 0 || options.width <= 0 || options.height <= 0) {
+      setPositions({});
+      setStable(true);
+      return;
+    }
+
+    const key = topologyKey(options);
+    const cached = layoutCache.get(key);
+    if (cached) {
+      setPositions(cached);
+      setStable(true);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setStable(false);
+    const worker = new Worker(new URL("../../../workers/atlas-layout.worker.ts", import.meta.url), {
+      type: "module",
+    });
+    worker.onmessage = (event: MessageEvent<AtlasLayoutResponse>) => {
+      if (event.data.requestId !== requestIdRef.current) return;
+      setPositions(event.data.positions);
+      if (event.data.type === "complete") {
+        layoutCache.set(key, event.data.positions);
+        setStable(true);
+        worker.terminate();
+      }
+    };
+    worker.onerror = () => {
+      const fallback = Object.fromEntries(
+        options.nodes.map((node, index) => {
+          const angle = (index / Math.max(options.nodes.length, 1)) * Math.PI * 2;
+          const radius = Math.min(options.width, options.height) * 0.32;
+          return [
+            node.id,
+            {
+              x: options.width / 2 + Math.cos(angle) * radius,
+              y: options.height / 2 + Math.sin(angle) * radius,
+            },
+          ];
+        }),
+      );
+      setPositions(fallback);
+      setStable(true);
+      worker.terminate();
+    };
+    worker.postMessage({
+      type: "layout",
+      requestId,
+      width: options.width,
+      height: options.height,
+      layout: options.layout,
+      selectedId: options.selectedId,
+      nodes: options.nodes.map((node) => ({
+        id: node.id,
+        entity_type: node.entity_type,
+        country_code: node.country_code,
+        connection_count: node.connection_count,
+      })),
+      edges: options.edges.map((edge) => ({
+        source_id: edge.source_id,
+        target_id: edge.target_id,
+        relation_type: edge.relation_type,
+        weight: edge.weight,
+      })),
+    });
+
+    return () => {
+      worker.postMessage({ type: "cancel", requestId });
+      worker.terminate();
+    };
+  }, [options]);
+
+  return { positions, stable };
+}

--- a/frontend/features/intelligence-atlas/intelligence-atlas-workspace.tsx
+++ b/frontend/features/intelligence-atlas/intelligence-atlas-workspace.tsx
@@ -54,13 +54,16 @@ function isWorkspaceTab(value: string): value is WorkspaceTab {
 }
 
 export function IntelligenceAtlasWorkspace() {
-  const pathname = usePathname();
-  const router = useRouter();
+  const currentPathname = usePathname();
+  const { push, replace } = useRouter();
   const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
   const queryClient = useQueryClient();
+  const pathnameRef = useRef(currentPathname);
+  pathnameRef.current = currentPathname;
   const parsedState = useMemo(
-    () => parseAtlasQueryState(new URLSearchParams(searchParams.toString())),
-    [searchParams],
+    () => parseAtlasQueryState(new URLSearchParams(searchParamsString)),
+    [searchParamsString],
   );
   const [searchText, setSearchText] = useState(parsedState.q);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -72,11 +75,11 @@ export function IntelligenceAtlasWorkspace() {
   const writeState = useCallback(
     (patch: Partial<AtlasQueryState>, mode: "push" | "replace" = "push") => {
       const query = serializeAtlasQueryState({ ...parsedState, ...patch }).toString();
-      const href = `${pathname || "/wiki/ownership"}${query ? `?${query}` : ""}`;
-      if (mode === "replace") router.replace(href, { scroll: false });
-      else router.push(href, { scroll: false });
+      const href = `${pathnameRef.current || "/wiki/ownership"}${query ? `?${query}` : ""}`;
+      if (mode === "replace") replace(href, { scroll: false });
+      else push(href, { scroll: false });
     },
-    [parsedState, pathname, router],
+    [parsedState, push, replace],
   );
 
   useEffect(() => setSearchText(parsedState.q), [parsedState.q]);
@@ -161,7 +164,7 @@ export function IntelligenceAtlasWorkspace() {
     return () => window.removeEventListener("keydown", handleGlobalKeyboard);
   }, [parsedState.focus, parsedState.panel, searchOpen, writeState]);
 
-  const nodes = graphQuery.data?.nodes ?? [];
+  const nodes = useMemo(() => graphQuery.data?.nodes ?? [], [graphQuery.data?.nodes]);
   const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
   const selectedNode = parsedState.selected ? nodesById.get(parsedState.selected) ?? null : null;
   useEffect(() => {

--- a/frontend/features/intelligence-atlas/intelligence-atlas-workspace.tsx
+++ b/frontend/features/intelligence-atlas/intelligence-atlas-workspace.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { WorkspaceTab } from "@/app/wiki/ownership/source-intelligence-support";
+import { GlobalNavigation } from "@/components/global-navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import { AtlasIndexSheet } from "./atlas-index-sheet";
+import { AtlasInspector } from "./atlas-inspector";
+import { AtlasOperationsSheet } from "./atlas-operations-sheet";
+import { AtlasStageShell } from "./atlas-stage-shell";
+import { AtlasTopbar } from "./atlas-topbar";
+import {
+  exportAtlas,
+  fetchAtlasEntity,
+  fetchAtlasGraph,
+  fetchAtlasStats,
+  searchAtlas,
+} from "./lib/atlas-api";
+import {
+  parseAtlasQueryState,
+  serializeAtlasQueryState,
+  type AtlasPanel,
+  type AtlasQueryState,
+} from "./lib/atlas-query-state";
+import {
+  metricPercentage,
+  type AtlasEntityType,
+  type AtlasGraphFilters,
+  type AtlasNode,
+  type AtlasSearchItem,
+} from "./lib/atlas-schema";
+import styles from "./atlas.module.css";
+
+function isWorkspaceTab(value: string): value is WorkspaceTab {
+  return ["ingestion", "storage", "parser", "llm", "errors", "performance", "media"].includes(value);
+}
+
+export function IntelligenceAtlasWorkspace() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const parsedState = useMemo(
+    () => parseAtlasQueryState(new URLSearchParams(searchParams.toString())),
+    [searchParams],
+  );
+  const [searchText, setSearchText] = useState(parsedState.q);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [activeSearchIndex, setActiveSearchIndex] = useState(0);
+  const [recentIds, setRecentIds] = useState<string[]>([]);
+  const [exporting, setExporting] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const writeState = useCallback(
+    (patch: Partial<AtlasQueryState>, mode: "push" | "replace" = "push") => {
+      const query = serializeAtlasQueryState({ ...parsedState, ...patch }).toString();
+      const href = `${pathname || "/wiki/ownership"}${query ? `?${query}` : ""}`;
+      if (mode === "replace") router.replace(href, { scroll: false });
+      else router.push(href, { scroll: false });
+    },
+    [parsedState, pathname, router],
+  );
+
+  useEffect(() => setSearchText(parsedState.q), [parsedState.q]);
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      if (searchText !== parsedState.q) {
+        writeState({ q: searchText, selected: searchText ? parsedState.selected : null }, "replace");
+      }
+    }, 220);
+    return () => window.clearTimeout(timer);
+  }, [parsedState.q, parsedState.selected, searchText, writeState]);
+
+  const graphFilters = useMemo<AtlasGraphFilters>(
+    () => ({
+      q: parsedState.q || null,
+      entity_types: parsedState.entities,
+      relation_types: parsedState.relations,
+      country: parsedState.country,
+      funding: parsedState.funding,
+      bias: parsedState.bias,
+      min_confidence: parsedState.minConfidence,
+      selected: parsedState.selected,
+      neighbors: parsedState.focus ? Math.max(parsedState.neighbors, 1) : parsedState.neighbors,
+      layout: parsedState.layout,
+      limit_nodes: 350,
+      limit_edges: 1500,
+      include_evidence_preview: true,
+    }),
+    [parsedState],
+  );
+
+  const graphQuery = useQuery({
+    queryKey: ["atlas", "graph", graphFilters],
+    queryFn: ({ signal }) => fetchAtlasGraph(graphFilters, signal),
+    staleTime: 60_000,
+    placeholderData: (previous) => previous,
+    retry: 1,
+  });
+  const statsQuery = useQuery({
+    queryKey: ["atlas", "stats"],
+    queryFn: ({ signal }) => fetchAtlasStats(signal),
+    staleTime: 30_000,
+    retry: 1,
+  });
+  const entityQuery = useQuery({
+    queryKey: ["atlas", "entity", parsedState.selected],
+    queryFn: ({ signal }) => fetchAtlasEntity(parsedState.selected ?? "", signal),
+    enabled: Boolean(parsedState.selected),
+    staleTime: 300_000,
+    retry: 1,
+  });
+  const searchQuery = useQuery({
+    queryKey: ["atlas", "search", searchText.trim()],
+    queryFn: ({ signal }) => searchAtlas(searchText.trim(), signal),
+    enabled: searchText.trim().length > 0 && searchOpen,
+    staleTime: 120_000,
+    retry: 1,
+  });
+
+  const searchItems = useMemo(
+    () => [
+      ...(searchQuery.data?.sources ?? []),
+      ...(searchQuery.data?.organizations ?? []),
+      ...(searchQuery.data?.reporters ?? []),
+    ],
+    [searchQuery.data],
+  );
+  useEffect(() => setActiveSearchIndex(0), [searchText]);
+  useEffect(() => {
+    function handleGlobalKeyboard(event: globalThis.KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+        setSearchOpen(true);
+      } else if (event.key === "Escape") {
+        if (searchOpen) setSearchOpen(false);
+        else if (parsedState.panel !== "none") writeState({ panel: "none" }, "replace");
+        else if (parsedState.focus) writeState({ focus: false, neighbors: 0 }, "replace");
+      }
+    }
+    window.addEventListener("keydown", handleGlobalKeyboard);
+    return () => window.removeEventListener("keydown", handleGlobalKeyboard);
+  }, [parsedState.focus, parsedState.panel, searchOpen, writeState]);
+
+  const nodes = graphQuery.data?.nodes ?? [];
+  const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const selectedNode = parsedState.selected ? nodesById.get(parsedState.selected) ?? null : null;
+  useEffect(() => {
+    if (parsedState.selected) {
+      setRecentIds((current) => [parsedState.selected!, ...current.filter((id) => id !== parsedState.selected)].slice(0, 8));
+    }
+  }, [parsedState.selected]);
+  const dockNodes = useMemo(() => {
+    const result: AtlasNode[] = [];
+    const seen = new Set<string>();
+    const recent = recentIds.map((id) => nodesById.get(id)).filter((node): node is AtlasNode => Boolean(node));
+    const popular = [...nodes].sort((left, right) => right.connection_count - left.connection_count).slice(0, 8);
+    for (const node of [...(selectedNode ? [selectedNode] : []), ...recent, ...popular]) {
+      if (!seen.has(node.id) && result.length < 7) {
+        seen.add(node.id);
+        result.push(node);
+      }
+    }
+    return result;
+  }, [nodes, nodesById, recentIds, selectedNode]);
+
+  function selectEntity(entityId: string, entityType?: AtlasEntityType) {
+    const entities = entityType && !parsedState.entities.includes(entityType)
+      ? [...parsedState.entities, entityType]
+      : parsedState.entities;
+    writeState({ selected: entityId, entities, neighbors: 1, panel: "inspector" });
+    setSearchOpen(false);
+  }
+  function chooseSearchResult(item: AtlasSearchItem) {
+    setSearchText(item.label);
+    const entities = parsedState.entities.includes(item.entity_type)
+      ? parsedState.entities
+      : [...parsedState.entities, item.entity_type];
+    writeState({ q: item.label, selected: item.id, entities, neighbors: 1, panel: "inspector" });
+    setSearchOpen(false);
+  }
+  function handleSearchKeyboard(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (searchItems.length > 0) {
+        const direction = event.key === "ArrowDown" ? 1 : -1;
+        setActiveSearchIndex((current) => (current + direction + searchItems.length) % searchItems.length);
+      }
+    } else if (event.key === "Enter") {
+      const item = searchItems[activeSearchIndex];
+      if (item) {
+        event.preventDefault();
+        chooseSearchResult(item);
+      }
+    }
+  }
+
+  async function refreshData() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["atlas", "graph"] }),
+      queryClient.invalidateQueries({ queryKey: ["atlas", "stats"] }),
+      parsedState.selected
+        ? queryClient.invalidateQueries({ queryKey: ["atlas", "entity", parsedState.selected] })
+        : Promise.resolve(),
+    ]);
+  }
+  async function handleExport() {
+    setExporting(true);
+    try {
+      await exportAtlas(graphFilters);
+    } finally {
+      setExporting(false);
+    }
+  }
+  function setPanel(panel: AtlasPanel) {
+    writeState({ panel }, "replace");
+  }
+
+  const operationsTab: WorkspaceTab = isWorkspaceTab(parsedState.tab) ? parsedState.tab : "ingestion";
+  const totalStats = statsQuery.data?.stats ?? graphQuery.data?.stats;
+  const coverage = totalStats ? metricPercentage(totalStats.ownership_coverage) : 0;
+  const selectedSourceName = entityQuery.data?.entity_type === "source"
+    ? entityQuery.data.label
+    : selectedNode?.entity_type === "source" ? selectedNode.label : null;
+
+  return (
+    <main className={styles.atlas}>
+      <div className={styles.shell}>
+        <GlobalNavigation />
+        <section className={styles.workspace} aria-label="SCOOP Intelligence Atlas workspace">
+          <AtlasTopbar
+            inputRef={searchInputRef}
+            searchText={searchText}
+            searchOpen={searchOpen}
+            searchItems={searchItems}
+            activeSearchIndex={activeSearchIndex}
+            searching={searchQuery.isFetching}
+            focus={parsedState.focus}
+            exporting={exporting}
+            refreshing={graphQuery.isFetching}
+            indexing={Boolean(statsQuery.data?.indexing_active)}
+            lastIndexed={statsQuery.data?.last_indexed_at}
+            onSearchChange={(event: ChangeEvent<HTMLInputElement>) => {
+              setSearchText(event.target.value);
+              setSearchOpen(true);
+            }}
+            onSearchFocus={() => setSearchOpen(true)}
+            onSearchKeyDown={handleSearchKeyboard}
+            onSearchHover={setActiveSearchIndex}
+            onChooseSearchResult={chooseSearchResult}
+            onToggleFocus={() => writeState({ focus: !parsedState.focus, neighbors: parsedState.focus ? 0 : 1 })}
+            onCopy={() => void navigator.clipboard?.writeText(window.location.href)}
+            onExport={() => void handleExport()}
+            onRefresh={() => void refreshData()}
+          />
+          <AtlasStageShell
+            state={parsedState}
+            graph={graphQuery.data}
+            graphVersion={graphQuery.data?.graph_version ?? "loading"}
+            loading={graphQuery.isLoading}
+            fetching={graphQuery.isFetching}
+            error={graphQuery.error instanceof Error ? graphQuery.error : null}
+            selectedNode={selectedNode}
+            dockNodes={dockNodes}
+            totalStats={totalStats}
+            ownershipCoverage={coverage}
+            onStateChange={(patch) => writeState(patch)}
+            onSelect={selectEntity}
+            onOpenIndex={() => setPanel("index")}
+            onOpenOperations={() => setPanel("operations")}
+            onRetry={() => void graphQuery.refetch()}
+          />
+        </section>
+      </div>
+
+      <Dialog open={parsedState.panel === "inspector" && Boolean(parsedState.selected)} onOpenChange={(open) => setPanel(open ? "inspector" : "none")}>
+        <DialogContent className="left-auto right-0 top-0 h-dvh w-[min(460px,100vw)] max-w-none translate-x-0 translate-y-0 gap-0 rounded-none border-y-0 border-r-0 border-white/10 bg-[#0d0f0c]/[0.98] p-0 text-[#f0ede4] shadow-2xl">
+          <DialogHeader className="sr-only">
+            <DialogTitle>Atlas entity inspector</DialogTitle>
+            <DialogDescription>Evidence and relationships for the selected Atlas entity.</DialogDescription>
+          </DialogHeader>
+          <AtlasInspector
+            record={entityQuery.data}
+            loading={entityQuery.isLoading}
+            error={entityQuery.error instanceof Error ? entityQuery.error : null}
+            onSelectConnection={(entityId) => selectEntity(entityId, nodesById.get(entityId)?.entity_type)}
+          />
+        </DialogContent>
+      </Dialog>
+      <AtlasIndexSheet
+        open={parsedState.panel === "index"}
+        onOpenChange={(open) => setPanel(open ? "index" : "none")}
+        entityTypes={parsedState.entities}
+        country={parsedState.country}
+        funding={parsedState.funding}
+        bias={parsedState.bias}
+        onSelect={(entityId) => selectEntity(entityId, nodesById.get(entityId)?.entity_type)}
+      />
+      <AtlasOperationsSheet
+        open={parsedState.panel === "operations"}
+        onOpenChange={(open) => setPanel(open ? "operations" : "none")}
+        activeTab={operationsTab}
+        onTabChange={(tab) => writeState({ panel: "operations", tab }, "replace")}
+        selectedSourceName={selectedSourceName}
+      />
+    </main>
+  );
+}

--- a/frontend/features/intelligence-atlas/lib/atlas-api.ts
+++ b/frontend/features/intelligence-atlas/lib/atlas-api.ts
@@ -1,0 +1,114 @@
+import { API_BASE_URL } from "@/lib/api";
+
+import {
+  AtlasEntityRecordSchema,
+  AtlasGraphResponseSchema,
+  AtlasIndexResponseSchema,
+  AtlasSearchResponseSchema,
+  AtlasStatsResponseSchema,
+  type AtlasGraphFilters,
+} from "./atlas-schema";
+
+function appendList(params: URLSearchParams, key: string, values: string[]): void {
+  if (values.length > 0) params.set(key, values.join(","));
+}
+
+async function parseResponse<T>(response: Response, parser: { parse: (value: unknown) => T }): Promise<T> {
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(detail || `Atlas request failed with status ${response.status}`);
+  }
+  return parser.parse(await response.json());
+}
+
+export function atlasGraphQueryString(filters: AtlasGraphFilters): string {
+  const params = new URLSearchParams();
+  if (filters.q) params.set("q", filters.q);
+  appendList(params, "entity_types", filters.entity_types);
+  appendList(params, "relation_types", filters.relation_types);
+  appendList(params, "country", filters.country);
+  appendList(params, "funding", filters.funding);
+  appendList(params, "bias", filters.bias);
+  if (filters.min_confidence > 0) params.set("min_confidence", String(filters.min_confidence));
+  if (filters.selected) params.set("selected", filters.selected);
+  if (filters.neighbors > 0) params.set("neighbors", String(filters.neighbors));
+  params.set("layout", filters.layout);
+  params.set("limit_nodes", String(filters.limit_nodes));
+  params.set("limit_edges", String(filters.limit_edges));
+  params.set("include_evidence_preview", String(filters.include_evidence_preview));
+  return params.toString();
+}
+
+export async function fetchAtlasGraph(filters: AtlasGraphFilters, signal?: AbortSignal) {
+  const query = atlasGraphQueryString(filters);
+  const response = await fetch(`${API_BASE_URL}/api/wiki/atlas/graph?${query}`, { signal });
+  return parseResponse(response, AtlasGraphResponseSchema);
+}
+
+export async function fetchAtlasStats(signal?: AbortSignal) {
+  const response = await fetch(`${API_BASE_URL}/api/wiki/atlas/stats`, { signal });
+  return parseResponse(response, AtlasStatsResponseSchema);
+}
+
+export async function searchAtlas(query: string, signal?: AbortSignal) {
+  const params = new URLSearchParams({ q: query, limit: "8" });
+  const response = await fetch(`${API_BASE_URL}/api/wiki/atlas/search?${params}`, { signal });
+  return parseResponse(response, AtlasSearchResponseSchema);
+}
+
+export async function fetchAtlasEntity(entityId: string, signal?: AbortSignal) {
+  const response = await fetch(`${API_BASE_URL}/api/wiki/atlas/entities/${encodeURIComponent(entityId)}`, { signal });
+  return parseResponse(response, AtlasEntityRecordSchema);
+}
+
+export async function fetchAtlasIndex(
+  params: {
+    entityTypes: string[];
+    q?: string;
+    country?: string[];
+    funding?: string[];
+    bias?: string[];
+    sort?: string;
+    cursor?: string | null;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+) {
+  const query = new URLSearchParams();
+  appendList(query, "entity_types", params.entityTypes);
+  if (params.q) query.set("q", params.q);
+  appendList(query, "country", params.country ?? []);
+  appendList(query, "funding", params.funding ?? []);
+  appendList(query, "bias", params.bias ?? []);
+  if (params.sort) query.set("sort", params.sort);
+  if (params.cursor) query.set("cursor", params.cursor);
+  query.set("limit", String(params.limit ?? 60));
+  const response = await fetch(`${API_BASE_URL}/api/wiki/atlas/index?${query}`, { signal });
+  return parseResponse(response, AtlasIndexResponseSchema);
+}
+
+export async function exportAtlas(
+  filters: AtlasGraphFilters,
+  format: "json" | "csv_nodes" | "csv_relationships" | "csv_evidence" = "json",
+): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/wiki/atlas/export`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      filters,
+      selected_entity: filters.selected,
+      format,
+      include_evidence: true,
+    }),
+  });
+  if (!response.ok) throw new Error(`Atlas export failed with status ${response.status}`);
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition") ?? "";
+  const filename = disposition.match(/filename="?([^";]+)"?/i)?.[1] ?? "atlas-investigation.json";
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/features/intelligence-atlas/lib/atlas-layout-protocol.ts
+++ b/frontend/features/intelligence-atlas/lib/atlas-layout-protocol.ts
@@ -1,0 +1,31 @@
+import type { AtlasEdge, AtlasNode } from "./atlas-schema";
+import type { AtlasLayoutMode } from "./atlas-query-state";
+
+export interface AtlasPosition {
+  x: number;
+  y: number;
+}
+
+export interface AtlasLayoutRequest {
+  type: "layout";
+  requestId: number;
+  width: number;
+  height: number;
+  layout: AtlasLayoutMode;
+  selectedId: string | null;
+  nodes: Array<Pick<AtlasNode, "id" | "entity_type" | "country_code" | "connection_count">>;
+  edges: Array<Pick<AtlasEdge, "source_id" | "target_id" | "relation_type" | "weight">>;
+}
+
+export interface AtlasLayoutCancelRequest {
+  type: "cancel";
+  requestId: number;
+}
+
+export interface AtlasLayoutResponse {
+  type: "positions" | "complete";
+  requestId: number;
+  positions: Record<string, AtlasPosition>;
+}
+
+export type AtlasWorkerRequest = AtlasLayoutRequest | AtlasLayoutCancelRequest;

--- a/frontend/features/intelligence-atlas/lib/atlas-query-state.ts
+++ b/frontend/features/intelligence-atlas/lib/atlas-query-state.ts
@@ -1,0 +1,115 @@
+import type { AtlasEntityType, AtlasRelationType } from "./atlas-schema";
+
+export type AtlasLayoutMode = "clustered" | "ownership" | "geography" | "radial";
+export type AtlasPanel = "none" | "inspector" | "index" | "operations";
+
+export interface AtlasQueryState {
+  q: string;
+  entities: AtlasEntityType[];
+  relations: AtlasRelationType[];
+  country: string[];
+  funding: string[];
+  bias: string[];
+  minConfidence: number;
+  selected: string | null;
+  neighbors: 0 | 1 | 2;
+  focus: boolean;
+  layout: AtlasLayoutMode;
+  panel: AtlasPanel;
+  tab: string;
+}
+
+const ENTITY_VALUES = new Set<AtlasEntityType>(["source", "organization", "reporter"]);
+const RELATION_VALUES = new Set<AtlasRelationType>([
+  "ownership",
+  "owned_by",
+  "parent_org",
+  "part_of",
+  "publishes",
+  "employed_by",
+  "current_outlet",
+  "coauthor",
+  "shared_outlet",
+]);
+const LAYOUT_VALUES = new Set<AtlasLayoutMode>(["clustered", "ownership", "geography", "radial"]);
+const PANEL_VALUES = new Set<AtlasPanel>(["none", "inspector", "index", "operations"]);
+
+export const DEFAULT_ATLAS_QUERY_STATE: AtlasQueryState = {
+  q: "",
+  entities: ["source", "organization"],
+  relations: ["ownership", "owned_by", "parent_org", "part_of", "publishes"],
+  country: [],
+  funding: [],
+  bias: [],
+  minConfidence: 0,
+  selected: null,
+  neighbors: 0,
+  focus: false,
+  layout: "clustered",
+  panel: "none",
+  tab: "ingestion",
+};
+
+function csvValues(value: string | null): string[] {
+  if (!value) return [];
+  return [...new Set(value.split(",").map((item) => item.trim()).filter(Boolean))];
+}
+
+function boundedNumber(value: string | null, fallback: number, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export function parseAtlasQueryState(params: URLSearchParams): AtlasQueryState {
+  const entities = csvValues(params.get("entities")).filter((value): value is AtlasEntityType =>
+    ENTITY_VALUES.has(value as AtlasEntityType),
+  );
+  const relations = csvValues(params.get("relations")).filter((value): value is AtlasRelationType =>
+    RELATION_VALUES.has(value as AtlasRelationType),
+  );
+  const layoutValue = params.get("layout") as AtlasLayoutMode | null;
+  const panelValue = params.get("panel") as AtlasPanel | null;
+  const neighborValue = Math.round(boundedNumber(params.get("neighbors"), 0, 0, 2)) as 0 | 1 | 2;
+
+  return {
+    q: params.get("q")?.slice(0, 200) ?? "",
+    entities: entities.length > 0 ? entities : DEFAULT_ATLAS_QUERY_STATE.entities,
+    relations: relations.length > 0 ? relations : DEFAULT_ATLAS_QUERY_STATE.relations,
+    country: csvValues(params.get("country")),
+    funding: csvValues(params.get("funding")),
+    bias: csvValues(params.get("bias")),
+    minConfidence: boundedNumber(params.get("min_confidence"), 0, 0, 1),
+    selected: params.get("selected")?.slice(0, 160) || null,
+    neighbors: neighborValue,
+    focus: params.get("focus") === "1",
+    layout: layoutValue && LAYOUT_VALUES.has(layoutValue) ? layoutValue : "clustered",
+    panel: panelValue && PANEL_VALUES.has(panelValue) ? panelValue : params.get("selected") ? "inspector" : "none",
+    tab: params.get("tab")?.slice(0, 40) || "ingestion",
+  };
+}
+
+export function serializeAtlasQueryState(state: AtlasQueryState): URLSearchParams {
+  const params = new URLSearchParams();
+  if (state.q.trim()) params.set("q", state.q.trim());
+  if (state.entities.length > 0) params.set("entities", state.entities.join(","));
+  if (state.relations.length > 0) params.set("relations", state.relations.join(","));
+  if (state.country.length > 0) params.set("country", state.country.join(","));
+  if (state.funding.length > 0) params.set("funding", state.funding.join(","));
+  if (state.bias.length > 0) params.set("bias", state.bias.join(","));
+  if (state.minConfidence > 0) params.set("min_confidence", String(state.minConfidence));
+  if (state.selected) params.set("selected", state.selected);
+  if (state.neighbors > 0) params.set("neighbors", String(state.neighbors));
+  if (state.focus) params.set("focus", "1");
+  if (state.layout !== "clustered") params.set("layout", state.layout);
+  if (state.panel !== "none") params.set("panel", state.panel);
+  if (state.panel === "operations" && state.tab) params.set("tab", state.tab);
+  return params;
+}
+
+export function updateAtlasQueryState(
+  current: AtlasQueryState,
+  patch: Partial<AtlasQueryState>,
+): AtlasQueryState {
+  return { ...current, ...patch };
+}

--- a/frontend/features/intelligence-atlas/lib/atlas-schema.ts
+++ b/frontend/features/intelligence-atlas/lib/atlas-schema.ts
@@ -1,0 +1,193 @@
+import { z } from "zod";
+
+export const AtlasEntityTypeSchema = z.enum(["source", "organization", "reporter"]);
+export const AtlasRelationTypeSchema = z.enum([
+  "ownership",
+  "owned_by",
+  "parent_org",
+  "part_of",
+  "publishes",
+  "employed_by",
+  "current_outlet",
+  "coauthor",
+  "shared_outlet",
+]);
+export const AtlasConfidenceTierSchema = z.enum([
+  "verified",
+  "strong",
+  "likely",
+  "unresolved",
+  "conflicting",
+  "stale",
+]);
+
+const NullableDateSchema = z.string().datetime({ offset: true }).nullable().optional();
+
+export const AtlasEvidenceSchema = z.object({
+  id: z.string(),
+  source_type: z.string(),
+  source_name: z.string().nullable().optional(),
+  source_url: z.string().nullable().optional(),
+  retrieved_at: NullableDateSchema,
+  excerpt: z.string().nullable().optional(),
+});
+
+export const AtlasNodeSchema = z.object({
+  id: z.string(),
+  entity_type: AtlasEntityTypeSchema,
+  label: z.string(),
+  subtitle: z.string().nullable().optional(),
+  country_code: z.string().nullable().optional(),
+  funding_type: z.string().nullable().optional(),
+  bias_rating: z.string().nullable().optional(),
+  factual_reporting: z.string().nullable().optional(),
+  credibility_score: z.number().nullable().optional(),
+  article_count: z.number().int().nonnegative().default(0),
+  connection_count: z.number().int().nonnegative().default(0),
+  ownership_connection_count: z.number().int().nonnegative().default(0),
+  status: z.string().nullable().optional(),
+  confidence_tier: AtlasConfidenceTierSchema.nullable().optional(),
+  profile_path: z.string().nullable().optional(),
+  updated_at: NullableDateSchema,
+  flags: z.array(z.string()).default([]),
+});
+
+export const AtlasEdgeSchema = z.object({
+  id: z.string(),
+  source_id: z.string(),
+  target_id: z.string(),
+  relation_type: AtlasRelationTypeSchema,
+  direction: z.enum(["directed", "undirected"]).default("directed"),
+  weight: z.number().default(1),
+  ownership_percentage: z.number().nullable().optional(),
+  confidence: z.number().min(0).max(1).nullable().optional(),
+  confidence_tier: AtlasConfidenceTierSchema.nullable().optional(),
+  evidence_count: z.number().int().nonnegative().default(0),
+  evidence_preview: z.array(AtlasEvidenceSchema).default([]),
+  valid_from: NullableDateSchema,
+  valid_to: NullableDateSchema,
+  last_verified_at: NullableDateSchema,
+  is_inferred: z.boolean().default(false),
+  raw_relation_type: z.string().nullable().optional(),
+});
+
+const AtlasCoverageMetricSchema = z.object({
+  numerator: z.number().int().nonnegative().default(0),
+  denominator: z.number().int().nonnegative().default(0),
+});
+
+export const AtlasStatsSchema = z.object({
+  total_sources: z.number().int().nonnegative().default(0),
+  total_organizations: z.number().int().nonnegative().default(0),
+  total_reporters: z.number().int().nonnegative().default(0),
+  visible_sources: z.number().int().nonnegative().default(0),
+  visible_organizations: z.number().int().nonnegative().default(0),
+  visible_reporters: z.number().int().nonnegative().default(0),
+  visible_relationships: z.number().int().nonnegative().default(0),
+  current_relationships: z.number().int().nonnegative().default(0),
+  ownership_coverage: AtlasCoverageMetricSchema,
+  evidence_coverage: AtlasCoverageMetricSchema,
+  unresolved_source_links: z.number().int().nonnegative().default(0),
+});
+
+export const AtlasGraphFiltersSchema = z.object({
+  q: z.string().nullable().optional(),
+  entity_types: z.array(AtlasEntityTypeSchema).default([]),
+  relation_types: z.array(AtlasRelationTypeSchema).default([]),
+  country: z.array(z.string()).default([]),
+  funding: z.array(z.string()).default([]),
+  bias: z.array(z.string()).default([]),
+  min_confidence: z.number().min(0).max(1).default(0),
+  selected: z.string().nullable().optional(),
+  neighbors: z.number().int().min(0).max(2).default(0),
+  layout: z.enum(["clustered", "ownership", "geography", "radial"]).default("clustered"),
+  limit_nodes: z.number().int().positive().default(350),
+  limit_edges: z.number().int().positive().default(1500),
+  include_evidence_preview: z.boolean().default(true),
+});
+
+export const AtlasGraphResponseSchema = z.object({
+  graph_version: z.string(),
+  generated_at: z.string().datetime({ offset: true }),
+  nodes: z.array(AtlasNodeSchema),
+  edges: z.array(AtlasEdgeSchema),
+  stats: AtlasStatsSchema,
+  applied_filters: AtlasGraphFiltersSchema,
+  truncated: z.boolean(),
+  truncation_reason: z.string().nullable().optional(),
+  next_expansion_token: z.string().nullable().optional(),
+});
+
+export const AtlasStatsResponseSchema = z.object({
+  graph_version: z.string(),
+  generated_at: z.string().datetime({ offset: true }),
+  stats: AtlasStatsSchema,
+  by_entity_type: z.record(z.string(), z.number()),
+  by_relation_type: z.record(z.string(), z.number()),
+  by_index_status: z.record(z.string(), z.number()),
+  last_indexed_at: NullableDateSchema,
+  indexing_active: z.boolean(),
+});
+
+export const AtlasSearchItemSchema = z.object({
+  id: z.string(),
+  entity_type: AtlasEntityTypeSchema,
+  label: z.string(),
+  subtitle: z.string().nullable().optional(),
+  country_code: z.string().nullable().optional(),
+  confidence_tier: AtlasConfidenceTierSchema.nullable().optional(),
+  profile_path: z.string().nullable().optional(),
+});
+
+export const AtlasSearchResponseSchema = z.object({
+  query: z.string(),
+  sources: z.array(AtlasSearchItemSchema),
+  organizations: z.array(AtlasSearchItemSchema),
+  reporters: z.array(AtlasSearchItemSchema),
+});
+
+export const AtlasConnectionSchema = z.object({
+  edge: AtlasEdgeSchema,
+  entity: AtlasNodeSchema,
+});
+
+export const AtlasEntityRecordSchema = z.object({
+  id: z.string(),
+  entity_type: AtlasEntityTypeSchema,
+  label: z.string(),
+  subtitle: z.string().nullable().optional(),
+  country_code: z.string().nullable().optional(),
+  status: z.string().nullable().optional(),
+  confidence_tier: AtlasConfidenceTierSchema.nullable().optional(),
+  last_verified_at: NullableDateSchema,
+  profile_path: z.string().nullable().optional(),
+  details: z.record(z.string(), z.unknown()),
+  evidence: z.array(AtlasEvidenceSchema),
+  connections: z.array(AtlasConnectionSchema),
+});
+
+export const AtlasIndexResponseSchema = z.object({
+  items: z.array(AtlasNodeSchema),
+  total: z.number().int().nonnegative(),
+  next_cursor: z.string().nullable().optional(),
+  facets: z.record(z.string(), z.record(z.string(), z.number())),
+});
+
+export type AtlasEntityType = z.infer<typeof AtlasEntityTypeSchema>;
+export type AtlasRelationType = z.infer<typeof AtlasRelationTypeSchema>;
+export type AtlasConfidenceTier = z.infer<typeof AtlasConfidenceTierSchema>;
+export type AtlasEvidence = z.infer<typeof AtlasEvidenceSchema>;
+export type AtlasNode = z.infer<typeof AtlasNodeSchema>;
+export type AtlasEdge = z.infer<typeof AtlasEdgeSchema>;
+export type AtlasGraphFilters = z.infer<typeof AtlasGraphFiltersSchema>;
+export type AtlasGraphResponse = z.infer<typeof AtlasGraphResponseSchema>;
+export type AtlasStatsResponse = z.infer<typeof AtlasStatsResponseSchema>;
+export type AtlasSearchItem = z.infer<typeof AtlasSearchItemSchema>;
+export type AtlasSearchResponse = z.infer<typeof AtlasSearchResponseSchema>;
+export type AtlasEntityRecord = z.infer<typeof AtlasEntityRecordSchema>;
+export type AtlasIndexResponse = z.infer<typeof AtlasIndexResponseSchema>;
+
+export function metricPercentage(metric: { numerator: number; denominator: number }): number {
+  if (metric.denominator <= 0) return 0;
+  return Math.round((metric.numerator / metric.denominator) * 1000) / 10;
+}

--- a/frontend/features/intelligence-atlas/tests/atlas-query-state.test.ts
+++ b/frontend/features/intelligence-atlas/tests/atlas-query-state.test.ts
@@ -1,0 +1,39 @@
+import {
+  DEFAULT_ATLAS_QUERY_STATE,
+  parseAtlasQueryState,
+  serializeAtlasQueryState,
+  type AtlasQueryState,
+} from "../lib/atlas-query-state";
+
+describe("Atlas query state", () => {
+  it("round-trips shareable investigation state", () => {
+    const state: AtlasQueryState = {
+      ...DEFAULT_ATLAS_QUERY_STATE,
+      q: "Reuters",
+      entities: ["source", "organization", "reporter"],
+      relations: ["ownership", "employed_by"],
+      country: ["GB", "US"],
+      funding: ["commercial"],
+      minConfidence: 0.65,
+      selected: "source:abc",
+      neighbors: 2,
+      focus: true,
+      layout: "radial",
+      panel: "inspector",
+    };
+
+    const parsed = parseAtlasQueryState(serializeAtlasQueryState(state));
+    expect(parsed).toEqual(state);
+  });
+
+  it("falls back safely for malformed values", () => {
+    const parsed = parseAtlasQueryState(
+      new URLSearchParams("entities=bad&relations=wrong&neighbors=99&layout=nope&min_confidence=8"),
+    );
+    expect(parsed.entities).toEqual(DEFAULT_ATLAS_QUERY_STATE.entities);
+    expect(parsed.relations).toEqual(DEFAULT_ATLAS_QUERY_STATE.relations);
+    expect(parsed.neighbors).toBe(2);
+    expect(parsed.layout).toBe("clustered");
+    expect(parsed.minConfidence).toBe(1);
+  });
+});

--- a/frontend/features/intelligence-atlas/tests/atlas-schema.test.ts
+++ b/frontend/features/intelligence-atlas/tests/atlas-schema.test.ts
@@ -1,0 +1,51 @@
+import { AtlasGraphResponseSchema, metricPercentage } from "../lib/atlas-schema";
+
+describe("Atlas runtime graph schema", () => {
+  it("accepts a bounded typed graph and rejects dangling shape errors", () => {
+    const graph = AtlasGraphResponseSchema.parse({
+      graph_version: "v1",
+      generated_at: "2026-07-19T12:00:00Z",
+      nodes: [
+        {
+          id: "source:abc",
+          entity_type: "source",
+          label: "Example",
+          article_count: 0,
+          connection_count: 1,
+          ownership_connection_count: 1,
+          flags: [],
+        },
+      ],
+      edges: [],
+      stats: {
+        total_sources: 1,
+        total_organizations: 0,
+        total_reporters: 0,
+        visible_sources: 1,
+        visible_organizations: 0,
+        visible_reporters: 0,
+        visible_relationships: 0,
+        current_relationships: 0,
+        ownership_coverage: { numerator: 0, denominator: 1 },
+        evidence_coverage: { numerator: 0, denominator: 0 },
+        unresolved_source_links: 1,
+      },
+      applied_filters: {
+        entity_types: ["source"],
+        relation_types: [],
+        country: [],
+        funding: [],
+        bias: [],
+        min_confidence: 0,
+        neighbors: 0,
+        layout: "clustered",
+        limit_nodes: 350,
+        limit_edges: 1500,
+        include_evidence_preview: true,
+      },
+      truncated: false,
+    });
+    expect(graph.nodes[0]?.id).toBe("source:abc");
+    expect(metricPercentage(graph.stats.ownership_coverage)).toBe(0);
+  });
+});

--- a/frontend/workers/atlas-layout.worker.ts
+++ b/frontend/workers/atlas-layout.worker.ts
@@ -1,0 +1,183 @@
+/// <reference lib="webworker" />
+
+import type {
+  AtlasLayoutRequest,
+  AtlasLayoutResponse,
+  AtlasPosition,
+  AtlasWorkerRequest,
+} from "../features/intelligence-atlas/lib/atlas-layout-protocol";
+
+const cancelled = new Set<number>();
+
+function hashValue(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function seededUnit(value: string, salt: number): number {
+  return (hashValue(`${value}:${salt}`) % 100000) / 100000;
+}
+
+function groupKey(node: AtlasLayoutRequest["nodes"][number], layout: AtlasLayoutRequest["layout"]): string {
+  if (layout === "geography") return node.country_code || "Unspecified";
+  if (layout === "ownership") return node.entity_type;
+  return node.entity_type;
+}
+
+function initialPosition(
+  node: AtlasLayoutRequest["nodes"][number],
+  index: number,
+  request: AtlasLayoutRequest,
+): AtlasPosition {
+  if (request.layout === "radial" && request.selectedId) {
+    if (node.id === request.selectedId) return { x: request.width / 2, y: request.height / 2 };
+    const angle = seededUnit(node.id, 9) * Math.PI * 2;
+    const ring = 150 + (index % 4) * 78;
+    return {
+      x: request.width / 2 + Math.cos(angle) * ring,
+      y: request.height / 2 + Math.sin(angle) * ring,
+    };
+  }
+
+  const key = groupKey(node, request.layout);
+  const groupHash = hashValue(key);
+  const centerAngle = (groupHash % 360) * (Math.PI / 180);
+  const groupRadius = Math.min(request.width, request.height) * 0.24;
+  const centerX = request.width / 2 + Math.cos(centerAngle) * groupRadius;
+  const centerY = request.height / 2 + Math.sin(centerAngle) * groupRadius;
+  const localAngle = seededUnit(node.id, 3) * Math.PI * 2;
+  const localRadius = 40 + seededUnit(node.id, 4) * 170;
+  return {
+    x: centerX + Math.cos(localAngle) * localRadius,
+    y: centerY + Math.sin(localAngle) * localRadius,
+  };
+}
+
+function runLayout(request: AtlasLayoutRequest): void {
+  const positions = new Map<string, AtlasPosition>();
+  const velocities = new Map<string, AtlasPosition>();
+  const adjacency = new Map<string, Set<string>>();
+
+  request.nodes.forEach((node, index) => {
+    positions.set(node.id, initialPosition(node, index, request));
+    velocities.set(node.id, { x: 0, y: 0 });
+    adjacency.set(node.id, new Set());
+  });
+  request.edges.forEach((edge) => {
+    adjacency.get(edge.source_id)?.add(edge.target_id);
+    adjacency.get(edge.target_id)?.add(edge.source_id);
+  });
+
+  const iterations = Math.min(180, Math.max(80, 220 - Math.floor(request.nodes.length / 4)));
+  const padding = 48;
+  let lastPosted = 0;
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    if (cancelled.has(request.requestId)) return;
+    const alpha = 1 - iteration / iterations;
+    const forces = new Map(request.nodes.map((node) => [node.id, { x: 0, y: 0 }]));
+
+    for (let leftIndex = 0; leftIndex < request.nodes.length; leftIndex += 1) {
+      const left = request.nodes[leftIndex]!;
+      const leftPosition = positions.get(left.id)!;
+      for (let rightIndex = leftIndex + 1; rightIndex < request.nodes.length; rightIndex += 1) {
+        const right = request.nodes[rightIndex]!;
+        const rightPosition = positions.get(right.id)!;
+        let dx = rightPosition.x - leftPosition.x;
+        let dy = rightPosition.y - leftPosition.y;
+        const distanceSquared = Math.max(dx * dx + dy * dy, 36);
+        const distance = Math.sqrt(distanceSquared);
+        dx /= distance;
+        dy /= distance;
+        const repulsion = Math.min(9, 1800 / distanceSquared) * alpha;
+        const leftForce = forces.get(left.id)!;
+        const rightForce = forces.get(right.id)!;
+        leftForce.x -= dx * repulsion;
+        leftForce.y -= dy * repulsion;
+        rightForce.x += dx * repulsion;
+        rightForce.y += dy * repulsion;
+      }
+    }
+
+    for (const edge of request.edges) {
+      const sourcePosition = positions.get(edge.source_id);
+      const targetPosition = positions.get(edge.target_id);
+      if (!sourcePosition || !targetPosition) continue;
+      let dx = targetPosition.x - sourcePosition.x;
+      let dy = targetPosition.y - sourcePosition.y;
+      const distance = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+      dx /= distance;
+      dy /= distance;
+      const desiredDistance = edge.relation_type === "ownership" ? 118 : 145;
+      const spring = (distance - desiredDistance) * 0.006 * Math.max(edge.weight, 0.25) * alpha;
+      const sourceForce = forces.get(edge.source_id)!;
+      const targetForce = forces.get(edge.target_id)!;
+      sourceForce.x += dx * spring;
+      sourceForce.y += dy * spring;
+      targetForce.x -= dx * spring;
+      targetForce.y -= dy * spring;
+    }
+
+    for (const node of request.nodes) {
+      const position = positions.get(node.id)!;
+      const force = forces.get(node.id)!;
+      const velocity = velocities.get(node.id)!;
+      const group = groupKey(node, request.layout);
+      const groupAngle = (hashValue(group) % 360) * (Math.PI / 180);
+      const groupingRadius = request.layout === "geography" ? 0.27 : 0.18;
+      let targetX = request.width / 2 + Math.cos(groupAngle) * request.width * groupingRadius;
+      let targetY = request.height / 2 + Math.sin(groupAngle) * request.height * groupingRadius;
+
+      if (request.layout === "radial" && request.selectedId) {
+        const graphDistance = adjacency.get(request.selectedId)?.has(node.id) ? 185 : 330;
+        const angle = seededUnit(node.id, 11) * Math.PI * 2;
+        targetX = request.width / 2 + Math.cos(angle) * (node.id === request.selectedId ? 0 : graphDistance);
+        targetY = request.height / 2 + Math.sin(angle) * (node.id === request.selectedId ? 0 : graphDistance);
+      }
+      if (request.layout === "ownership" && node.entity_type === "organization") {
+        targetX = request.width * 0.42;
+        targetY = request.height * 0.48;
+      } else if (request.layout === "ownership" && node.entity_type === "source") {
+        targetX = request.width * 0.64;
+      }
+
+      force.x += (targetX - position.x) * 0.0035 * alpha;
+      force.y += (targetY - position.y) * 0.0035 * alpha;
+      velocity.x = (velocity.x + force.x) * 0.82;
+      velocity.y = (velocity.y + force.y) * 0.82;
+      position.x = Math.min(request.width - padding, Math.max(padding, position.x + velocity.x));
+      position.y = Math.min(request.height - padding, Math.max(padding, position.y + velocity.y));
+    }
+
+    const now = performance.now();
+    if (now - lastPosted > 48 && iteration < iterations - 1) {
+      lastPosted = now;
+      const response: AtlasLayoutResponse = {
+        type: "positions",
+        requestId: request.requestId,
+        positions: Object.fromEntries(positions),
+      };
+      self.postMessage(response);
+    }
+  }
+
+  const response: AtlasLayoutResponse = {
+    type: "complete",
+    requestId: request.requestId,
+    positions: Object.fromEntries(positions),
+  };
+  self.postMessage(response);
+  cancelled.delete(request.requestId);
+}
+
+self.addEventListener("message", (event: MessageEvent<AtlasWorkerRequest>) => {
+  if (event.data.type === "cancel") {
+    cancelled.add(event.data.requestId);
+    return;
+  }
+  runLayout(event.data);
+});


### PR DESCRIPTION
## Summary

- replace `/wiki/ownership` with the graph-first SCOOP Intelligence Atlas workspace
- add typed, bounded `/api/wiki/atlas` graph, stats, search, entity, connections, index, and export contracts
- remove substring-based ownership matching from the new graph projection and preserve ambiguous records as unresolved
- attach confidence, provenance, validity, verification dates, and evidence previews to material relationships
- add an idempotent dry-run-first relationship backfill and integrity regressions for short/ambiguous names
- add URL-restorable investigation state, grouped search, filters, focus mode, record dock, entity inspector, virtualized index, and isolated operations sheet
- move deterministic graph layout into a Web Worker and add pointer pan/zoom, roving keyboard focus, semantic node labels, and an accessible list equivalent
- add versioned JSON/CSV evidence exports and Atlas implementation documentation

## Verification performed

- `uvx ruff format` on all added/modified backend Python files
- `uvx ruff check` on all added/modified backend Python files
- strict isolated TypeScript check with the repository's React, Next, TanStack Query, TanStack Virtual, and Zod versions
- runtime checks for Atlas query-state round trips and graph schema validation
- backend contract tests for typed graph IDs/limits and relationship integrity fixtures

## Verification limitation

The sandbox could not clone or reach GitHub over the network, so publication used the connected GitHub API and I could not run the repository-wide `npm build`, complete Jest suite, or database-backed pytest suite against a full checkout. CI should run those repository-level checks before merge.

## Migration notes

- `/wiki/ownership` remains canonical and the navigation label becomes **Intelligence Atlas**.
- the legacy `/api/wiki/organizations/graph` endpoint is left untouched during migration.
- the existing source operations implementation is retained and mounted in a separate bottom sheet.
- relationship backfill defaults to dry-run and writes an audit artifact before any apply run.