### PR TITLE
Add agent-readable debug bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Active thesis project. The app runs locally with `runlocal.sh` or Docker Compose
 - Source and reporter wiki pages, including ownership and reporter graph views backed by deterministic indexing and public-source evidence.
 - Research agents for article search, source context, and verification workflows.
 - Semantic search through ChromaDB with lexical fallback paths.
-- Operator/debug surfaces for cache status, source health, logs, and wiki indexing.
+- Operator/debug surfaces for cache status, source health, logs, wiki indexing, resource use, and agent-readable debug bundles.
 
 ## Requirements
 
@@ -69,6 +69,9 @@ Common variables:
 | `CHROMA_HOST` / `CHROMA_PORT` | Points the backend at ChromaDB. |
 | `EMBEDDING_SERVICE_URL` | Points the backend at the embedding worker. |
 | `NEXT_PUBLIC_API_URL` | Overrides the browser API base URL when needed. |
+| `THESIS_RUNTIME_DIR` | Stores local structured logs, resource samples, and traces. |
+| `THESIS_OBSERVABILITY_ENABLED` | Enables lightweight resource sampling; defaults to enabled. |
+| `OTEL_ENABLED` | Enables local JSONL OpenTelemetry trace export. |
 
 Restart the backend after changing `backend/.env`.
 
@@ -99,6 +102,14 @@ Run dependency cycle checks:
 ```bash
 npm run deps:cycles
 ```
+
+Collect an agent-readable debug bundle after reproducing a problem:
+
+```bash
+./scripts/collect-debug-bundle --since 30m
+```
+
+See [Evidence-based debugging](docs/agent-debugging.md) for the file layout, correlation fields, privacy rules, endpoints, and optional deeper profilers.
 
 ## Frontend architecture
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Common variables:
 | `NEXT_PUBLIC_API_URL` | Overrides the browser API base URL when needed. |
 | `THESIS_RUNTIME_DIR` | Stores local structured logs, resource samples, and traces. |
 | `THESIS_OBSERVABILITY_ENABLED` | Enables lightweight resource sampling; defaults to enabled. |
+| `THESIS_LOG_MAX_BYTES` / `THESIS_LOG_BACKUP_COUNT` | Bounds each runtime JSONL file; defaults to 25 MiB plus three backups. |
 | `OTEL_ENABLED` | Enables local JSONL OpenTelemetry trace export. |
 
 Restart the backend after changing `backend/.env`.

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -22,6 +22,7 @@ from . import (
     liked,
     news,
     news_by_country,
+    observability,
     profiling,
     reading_queue,
     research,
@@ -55,6 +56,7 @@ router.include_router(news_by_country.router)
 router.include_router(cache.router)
 router.include_router(stream.router)
 router.include_router(debug.router)
+router.include_router(observability.router)
 router.include_router(bookmarks.router)
 router.include_router(liked.router)
 router.include_router(reading_queue.router)

--- a/backend/app/api/routes/observability.py
+++ b/backend/app/api/routes/observability.py
@@ -7,20 +7,16 @@ import contextlib
 import os
 import platform
 import sys
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, FastAPI, Query
 
 from app.core.logging import get_runtime_data_dir, get_runtime_log_dir
 from app.services.resource_monitor import read_jsonl_records, resource_monitor
 
-router = APIRouter(
-    prefix="/debug/observability",
-    tags=["debug", "observability"],
-    include_in_schema=False,
-)
 _event_loop_task: asyncio.Task[None] | None = None
 
 
@@ -35,7 +31,6 @@ async def _sample_event_loop_lag() -> None:
         expected = now + interval
 
 
-@router.on_event("startup")
 async def start_observability() -> None:
     """Start low-overhead resource and event-loop sampling."""
     global _event_loop_task
@@ -47,7 +42,6 @@ async def start_observability() -> None:
         )
 
 
-@router.on_event("shutdown")
 async def stop_observability() -> None:
     """Stop observability tasks without delaying application shutdown."""
     global _event_loop_task
@@ -59,10 +53,28 @@ async def stop_observability() -> None:
     resource_monitor.stop()
 
 
+@contextlib.asynccontextmanager
+async def observability_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Own the sampler and event-loop probe for the router lifetime."""
+    await start_observability()
+    try:
+        yield
+    finally:
+        await stop_observability()
+
+
+router = APIRouter(
+    prefix="/debug/observability",
+    tags=["debug", "observability"],
+    include_in_schema=False,
+    lifespan=observability_lifespan,
+)
+
+
 @router.get("/resources")
 async def get_resource_snapshot() -> dict[str, Any]:
     """Return a current CPU, memory, disk, network, process, and GPU snapshot."""
-    return resource_monitor.collect_snapshot()
+    return await asyncio.to_thread(resource_monitor.collect_snapshot)
 
 
 @router.get("/performance")
@@ -74,7 +86,12 @@ async def get_recent_performance_samples(
     log_dir = get_runtime_log_dir()
     paths = sorted(log_dir.rglob("performance_*.jsonl"))
     since = datetime.now(UTC) - timedelta(minutes=since_minutes)
-    records = read_jsonl_records(paths, limit=limit, since=since)
+    records = await asyncio.to_thread(
+        read_jsonl_records,
+        paths,
+        limit=limit,
+        since=since,
+    )
     return {
         "generated_at": datetime.now(UTC).isoformat(),
         "since_minutes": since_minutes,
@@ -110,9 +127,7 @@ async def get_runtime_context() -> dict[str, Any]:
             {
                 "path": str(path),
                 "size_bytes": path.stat().st_size,
-                "modified_at": datetime.fromtimestamp(
-                    path.stat().st_mtime, tz=UTC
-                ).isoformat(),
+                "modified_at": datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).isoformat(),
             }
             for path in sorted(log_dir.rglob("*.jsonl"))
             if path.is_file()
@@ -129,5 +144,5 @@ async def get_observability_health() -> dict[str, Any]:
         "monitor_running": resource_monitor.running,
         "performance_log_exists": log_path.exists(),
         "performance_log_path": str(log_path),
-        "latest_sample": resource_monitor.latest_snapshot(),
+        "latest_sample": await asyncio.to_thread(resource_monitor.latest_snapshot),
     }

--- a/backend/app/api/routes/observability.py
+++ b/backend/app/api/routes/observability.py
@@ -1,0 +1,133 @@
+"""Small, local-first observability endpoints for agentic debugging."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import platform
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from app.core.logging import get_runtime_data_dir, get_runtime_log_dir
+from app.services.resource_monitor import read_jsonl_records, resource_monitor
+
+router = APIRouter(
+    prefix="/debug/observability",
+    tags=["debug", "observability"],
+    include_in_schema=False,
+)
+_event_loop_task: asyncio.Task[None] | None = None
+
+
+async def _sample_event_loop_lag() -> None:
+    interval = 1.0
+    loop = asyncio.get_running_loop()
+    expected = loop.time() + interval
+    while True:
+        await asyncio.sleep(interval)
+        now = loop.time()
+        resource_monitor.set_event_loop_lag((now - expected) * 1000)
+        expected = now + interval
+
+
+@router.on_event("startup")
+async def start_observability() -> None:
+    """Start low-overhead resource and event-loop sampling."""
+    global _event_loop_task
+    resource_monitor.start()
+    if _event_loop_task is None or _event_loop_task.done():
+        _event_loop_task = asyncio.create_task(
+            _sample_event_loop_lag(),
+            name="observability_event_loop_lag",
+        )
+
+
+@router.on_event("shutdown")
+async def stop_observability() -> None:
+    """Stop observability tasks without delaying application shutdown."""
+    global _event_loop_task
+    if _event_loop_task is not None:
+        _event_loop_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _event_loop_task
+        _event_loop_task = None
+    resource_monitor.stop()
+
+
+@router.get("/resources")
+async def get_resource_snapshot() -> dict[str, Any]:
+    """Return a current CPU, memory, disk, network, process, and GPU snapshot."""
+    return resource_monitor.collect_snapshot()
+
+
+@router.get("/performance")
+async def get_recent_performance_samples(
+    limit: int = Query(200, ge=1, le=5000),
+    since_minutes: int = Query(30, ge=1, le=24 * 60),
+) -> dict[str, Any]:
+    """Return recent persisted performance samples across local services."""
+    log_dir = get_runtime_log_dir()
+    paths = sorted(log_dir.rglob("performance_*.jsonl"))
+    since = datetime.now(UTC) - timedelta(minutes=since_minutes)
+    records = read_jsonl_records(paths, limit=limit, since=since)
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "since_minutes": since_minutes,
+        "returned": len(records),
+        "files": [str(path) for path in paths],
+        "samples": records,
+    }
+
+
+@router.get("/runtime")
+async def get_runtime_context() -> dict[str, Any]:
+    """Return code-adjacent runtime facts useful in a debug bundle."""
+    runtime_dir = get_runtime_data_dir()
+    log_dir = get_runtime_log_dir()
+    return {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "service": resource_monitor.service_name,
+        "pid": os.getpid(),
+        "python": sys.version,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "runtime_data_dir": str(runtime_dir),
+        "runtime_log_dir": str(log_dir),
+        "resource_monitor": {
+            "enabled": os.getenv("THESIS_OBSERVABILITY_ENABLED", "1")
+            not in {"0", "false", "False", ""},
+            "running": resource_monitor.running,
+            "interval_seconds": resource_monitor.interval_seconds,
+            "log_path": str(resource_monitor.log_path),
+        },
+        "log_files": [
+            {
+                "path": str(path),
+                "size_bytes": path.stat().st_size,
+                "modified_at": datetime.fromtimestamp(
+                    path.stat().st_mtime, tz=UTC
+                ).isoformat(),
+            }
+            for path in sorted(log_dir.rglob("*.jsonl"))
+            if path.is_file()
+        ],
+    }
+
+
+@router.get("/health")
+async def get_observability_health() -> dict[str, Any]:
+    """Report whether the lightweight evidence pipeline is running."""
+    log_path: Path = resource_monitor.log_path
+    return {
+        "status": "healthy" if resource_monitor.running else "degraded",
+        "monitor_running": resource_monitor.running,
+        "performance_log_exists": log_path.exists(),
+        "performance_log_path": str(log_path),
+        "latest_sample": resource_monitor.latest_snapshot(),
+    }

--- a/backend/app/core/file_trace_exporter.py
+++ b/backend/app/core/file_trace_exporter.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
-import json
 import os
 import threading
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult, SpanExporter
 from opentelemetry.trace import format_span_id, format_trace_id
 
+from app.core.jsonl import append_jsonl
 from app.core.logging import get_runtime_log_dir
 
 
@@ -36,6 +37,7 @@ class JsonlSpanExporter(SpanExporter):
     """Persist completed spans in a format both humans and agents can inspect."""
 
     def __init__(self, *, service_name: str, log_dir: Path | None = None) -> None:
+        """Create a bounded file exporter for one service process."""
         safe_service = "".join(
             character if character.isalnum() or character in {"-", "_"} else "_"
             for character in service_name
@@ -47,12 +49,13 @@ class JsonlSpanExporter(SpanExporter):
 
     @property
     def path(self) -> Path:
+        """Return the active JSONL path."""
         return self._path
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        """Append completed spans to the bounded local trace log."""
         try:
-            with self._lock, self._path.open("a", encoding="utf-8") as handle:
+            with self._lock:
                 for span in spans:
                     context = span.context
                     parent = span.parent
@@ -64,24 +67,19 @@ class JsonlSpanExporter(SpanExporter):
                         else None
                     )
                     payload = {
-                        "timestamp": _iso_from_ns(end_ns)
-                        or datetime.now(UTC).isoformat(),
+                        "timestamp": _iso_from_ns(end_ns) or datetime.now(UTC).isoformat(),
                         "kind": "trace_span",
                         "service": span.resource.attributes.get("service.name"),
                         "trace_id": format_trace_id(context.trace_id),
                         "span_id": format_span_id(context.span_id),
-                        "parent_span_id": format_span_id(parent.span_id)
-                        if parent
-                        else None,
+                        "parent_span_id": format_span_id(parent.span_id) if parent else None,
                         "operation": span.name,
                         "span_kind": span.kind.name,
                         "status": span.status.status_code.name,
                         "status_description": span.status.description,
                         "start_time": _iso_from_ns(start_ns),
                         "end_time": _iso_from_ns(end_ns),
-                        "duration_ms": round(duration_ms, 3)
-                        if duration_ms is not None
-                        else None,
+                        "duration_ms": round(duration_ms, 3) if duration_ms is not None else None,
                         "attributes": _json_safe(dict(span.attributes or {})),
                         "events": [
                             {
@@ -92,15 +90,15 @@ class JsonlSpanExporter(SpanExporter):
                             for event in span.events
                         ],
                     }
-                    handle.write(
-                        json.dumps(payload, separators=(",", ":"), default=str) + "\n"
-                    )
+                    append_jsonl(self._path, payload)
         except OSError:
             return SpanExportResult.FAILURE
         return SpanExportResult.SUCCESS
 
     def shutdown(self) -> None:
+        """Release exporter resources; writes do not keep an open handle."""
         return None
 
     def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Report success because every export is flushed on append."""
         return True

--- a/backend/app/core/file_trace_exporter.py
+++ b/backend/app/core/file_trace_exporter.py
@@ -1,0 +1,106 @@
+"""OpenTelemetry span exporter that writes compact JSON Lines locally."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult, SpanExporter
+from opentelemetry.trace import format_span_id, format_trace_id
+
+from app.core.logging import get_runtime_log_dir
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    return str(value)
+
+
+def _iso_from_ns(value: int | None) -> str | None:
+    if value is None:
+        return None
+    return datetime.fromtimestamp(value / 1_000_000_000, tz=UTC).isoformat()
+
+
+class JsonlSpanExporter(SpanExporter):
+    """Persist completed spans in a format both humans and agents can inspect."""
+
+    def __init__(self, *, service_name: str, log_dir: Path | None = None) -> None:
+        safe_service = "".join(
+            character if character.isalnum() or character in {"-", "_"} else "_"
+            for character in service_name
+        )
+        self._path = (log_dir or get_runtime_log_dir()) / (
+            f"traces_{safe_service}_{os.getpid()}.jsonl"
+        )
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with self._lock, self._path.open("a", encoding="utf-8") as handle:
+                for span in spans:
+                    context = span.context
+                    parent = span.parent
+                    start_ns = span.start_time
+                    end_ns = span.end_time
+                    duration_ms = (
+                        (end_ns - start_ns) / 1_000_000
+                        if start_ns is not None and end_ns is not None
+                        else None
+                    )
+                    payload = {
+                        "timestamp": _iso_from_ns(end_ns)
+                        or datetime.now(UTC).isoformat(),
+                        "kind": "trace_span",
+                        "service": span.resource.attributes.get("service.name"),
+                        "trace_id": format_trace_id(context.trace_id),
+                        "span_id": format_span_id(context.span_id),
+                        "parent_span_id": format_span_id(parent.span_id)
+                        if parent
+                        else None,
+                        "operation": span.name,
+                        "span_kind": span.kind.name,
+                        "status": span.status.status_code.name,
+                        "status_description": span.status.description,
+                        "start_time": _iso_from_ns(start_ns),
+                        "end_time": _iso_from_ns(end_ns),
+                        "duration_ms": round(duration_ms, 3)
+                        if duration_ms is not None
+                        else None,
+                        "attributes": _json_safe(dict(span.attributes or {})),
+                        "events": [
+                            {
+                                "name": event.name,
+                                "timestamp": _iso_from_ns(event.timestamp),
+                                "attributes": _json_safe(dict(event.attributes or {})),
+                            }
+                            for event in span.events
+                        ],
+                    }
+                    handle.write(
+                        json.dumps(payload, separators=(",", ":"), default=str) + "\n"
+                    )
+        except OSError:
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        return None
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True

--- a/backend/app/core/jsonl.py
+++ b/backend/app/core/jsonl.py
@@ -1,0 +1,78 @@
+"""Bounded JSON Lines file writes for local runtime evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MAX_BYTES = 25 * 1024 * 1024
+DEFAULT_BACKUP_COUNT = 3
+SENSITIVE_KEY = re.compile(
+    r"(?:^|[_-])(?:api[_-]?key|key|token|secret|password|cookie|authorization)"
+    r"(?:$|[_-])",
+    re.IGNORECASE,
+)
+SENSITIVE_ASSIGNMENT = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password|cookie|authorization)\b"
+    r"(\s*[:=]\s*)([^\s,;]+)"
+)
+URL_QUERY_VALUE = re.compile(r"([?&][^=\s&#]+)=([^&#\s]*)")
+URL_PASSWORD = re.compile(r"(\b[a-z][a-z0-9+.-]*://[^:/\s@]+):([^@\s/]+)@", re.I)
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _backup_path(path: Path, index: int) -> Path:
+    return path.with_name(f"{path.stem}.{index}{path.suffix}")
+
+
+def sanitize_runtime_value(value: object, *, key: str = "") -> object:
+    """Redact secrets and URL values before writing local runtime evidence."""
+    if SENSITIVE_KEY.search(key):
+        return "<redacted>"
+    if isinstance(value, dict):
+        return {
+            str(item_key): sanitize_runtime_value(item, key=str(item_key))
+            for item_key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [sanitize_runtime_value(item) for item in value]
+    if isinstance(value, str):
+        value = URL_PASSWORD.sub(r"\1:<redacted>@", value)
+        value = URL_QUERY_VALUE.sub(r"\1=<redacted>", value)
+        return SENSITIVE_ASSIGNMENT.sub(r"\1\2<redacted>", value)
+    return value
+
+
+def append_jsonl(path: Path, value: dict[str, Any]) -> None:
+    """Append one record and rotate the file before it exceeds its size cap.
+
+    Callers that can write from more than one thread must hold their own lock.
+    """
+    line = json.dumps(sanitize_runtime_value(value), separators=(",", ":"), default=str) + "\n"
+    encoded_size = len(line.encode("utf-8"))
+    max_bytes = _positive_env_int("THESIS_LOG_MAX_BYTES", DEFAULT_MAX_BYTES)
+    backup_count = _positive_env_int("THESIS_LOG_BACKUP_COUNT", DEFAULT_BACKUP_COUNT)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    current_size = path.stat().st_size if path.exists() else 0
+    if current_size and current_size + encoded_size > max_bytes:
+        oldest = _backup_path(path, backup_count)
+        oldest.unlink(missing_ok=True)
+        for index in range(backup_count - 1, 0, -1):
+            source = _backup_path(path, index)
+            if source.exists():
+                source.replace(_backup_path(path, index + 1))
+        path.replace(_backup_path(path, 1))
+
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,4 +1,6 @@
-"""Logging."""
+"""Project logging and runtime-data paths."""
+
+from __future__ import annotations
 
 import logging
 import os
@@ -6,9 +8,21 @@ from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - [%(funcName)s:%(lineno)d] - %(message)s"
+_LOG_FORMAT = (
+    "%(asctime)s - %(name)s - %(levelname)s - [%(funcName)s:%(lineno)d] - %(message)s"
+)
 
-LOG_DIR = Path(os.environ.get("LOG_DIR", Path(__file__).parent.parent.parent / "logs"))
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_DATA_DIR = Path(
+    os.environ.get("THESIS_RUNTIME_DIR", REPO_ROOT / "runtime-data")
+)
+RUNTIME_LOG_DIR = RUNTIME_DATA_DIR / "logs"
+
+# Keep the existing structured debug logger, but point it at durable project data
+# unless a deployment explicitly chooses another directory.
+os.environ.setdefault("DEBUG_LOG_DIR", str(RUNTIME_LOG_DIR))
+
+LOG_DIR = Path(os.environ.get("LOG_DIR", RUNTIME_LOG_DIR / "sessions"))
 MAX_LOG_SIZE = 10 * 1024 * 1024  # 10 MB
 BACKUP_COUNT = 3
 
@@ -20,7 +34,9 @@ class ConsoleSummaryFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return whether a record belongs in the operational console."""
-        return record.levelno >= logging.WARNING or bool(getattr(record, "console_summary", False))
+        return record.levelno >= logging.WARNING or bool(
+            getattr(record, "console_summary", False)
+        )
 
 
 class ConsoleSummaryFormatter(logging.Formatter):
@@ -42,8 +58,20 @@ class ConsoleSummaryFormatter(logging.Formatter):
             record.stack_info = stack_info
 
 
+def get_runtime_data_dir() -> Path:
+    """Return the configured runtime-data directory, creating it when needed."""
+    RUNTIME_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    return RUNTIME_DATA_DIR
+
+
+def get_runtime_log_dir() -> Path:
+    """Return the configured structured-log directory."""
+    RUNTIME_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    return RUNTIME_LOG_DIR
+
+
 def get_session_dir() -> Path:
-    """Get Session Dir."""
+    """Return the current plain-text application-log session directory."""
     global _session_dir
     if _session_dir is None:
         session_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -79,8 +107,8 @@ def configure_logging(level: int = logging.INFO) -> logging.Logger:
         )
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
-    except (OSError, PermissionError) as e:
-        root_logger.warning("Could not create log file: %s", e)
+    except (OSError, PermissionError) as exc:
+        root_logger.warning("Could not create log file: %s", exc)
 
     return logging.getLogger("app")
 

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -8,14 +8,10 @@ from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-_LOG_FORMAT = (
-    "%(asctime)s - %(name)s - %(levelname)s - [%(funcName)s:%(lineno)d] - %(message)s"
-)
+_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - [%(funcName)s:%(lineno)d] - %(message)s"
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-RUNTIME_DATA_DIR = Path(
-    os.environ.get("THESIS_RUNTIME_DIR", REPO_ROOT / "runtime-data")
-)
+RUNTIME_DATA_DIR = Path(os.environ.get("THESIS_RUNTIME_DIR", REPO_ROOT / "runtime-data"))
 RUNTIME_LOG_DIR = RUNTIME_DATA_DIR / "logs"
 
 # Keep the existing structured debug logger, but point it at durable project data
@@ -34,9 +30,7 @@ class ConsoleSummaryFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Return whether a record belongs in the operational console."""
-        return record.levelno >= logging.WARNING or bool(
-            getattr(record, "console_summary", False)
-        )
+        return record.levelno >= logging.WARNING or bool(getattr(record, "console_summary", False))
 
 
 class ConsoleSummaryFormatter(logging.Formatter):
@@ -74,7 +68,7 @@ def get_session_dir() -> Path:
     """Return the current plain-text application-log session directory."""
     global _session_dir
     if _session_dir is None:
-        session_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        session_name = f"{datetime.now():%Y-%m-%d_%H-%M-%S}_{os.getpid()}"
         _session_dir = LOG_DIR / session_name
         _session_dir.mkdir(parents=True, exist_ok=True)
     return _session_dir

--- a/backend/app/core/tracing.py
+++ b/backend/app/core/tracing.py
@@ -49,9 +49,7 @@ def setup_tracing(app: FastAPI) -> None:
 
         from app.core.file_trace_exporter import JsonlSpanExporter
     except ImportError as exc:
-        _logger.warning(
-            "OpenTelemetry dependencies not installed: %s; tracing disabled", exc
-        )
+        _logger.warning("OpenTelemetry dependencies not installed: %s; tracing disabled", exc)
         return
 
     sample_rate = max(0.0, min(1.0, settings.otel_sample_rate))
@@ -83,17 +81,11 @@ def setup_tracing(app: FastAPI) -> None:
             )
 
             provider.add_span_processor(
-                BatchSpanProcessor(
-                    OTLPSpanExporter(endpoint=settings.otel_exporter_endpoint)
-                )
+                BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.otel_exporter_endpoint))
             )
-            _logger.info(
-                "OTLP exporter configured at %s", settings.otel_exporter_endpoint
-            )
+            _logger.info("OTLP exporter configured at %s", settings.otel_exporter_endpoint)
         except ImportError:
-            _logger.warning(
-                "OTLP exporter not installed; local file export remains active"
-            )
+            _logger.warning("OTLP exporter not installed; local file export remains active")
         except Exception as exc:
             _logger.warning("Failed to configure OTLP exporter: %s", exc)
 

--- a/backend/app/core/tracing.py
+++ b/backend/app/core/tracing.py
@@ -1,35 +1,40 @@
-"""Tracing."""
+"""OpenTelemetry tracing with local JSONL export for debug bundles."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+import os
+from typing import Any
 
 from fastapi import FastAPI
 
 from app.core.config import settings
 
 TRACER_NAME = "scoop-backend"
-
 _logger = logging.getLogger("app.tracing")
 
 
 def _tracer_provider_configured() -> bool:
     try:
+        from opentelemetry import trace
         from opentelemetry.sdk.trace import TracerProvider
 
-        return isinstance(
-            cast(Any, __import__("opentelemetry.trace").trace).get_tracer_provider(),
-            TracerProvider,
-        )
+        return isinstance(trace.get_tracer_provider(), TracerProvider)
     except Exception:
         return False
 
 
 def setup_tracing(app: FastAPI) -> None:
-    """Setup Tracing."""
+    """Configure tracing when OTEL_ENABLED is set."""
     if not settings.otel_enabled:
         _logger.info("OpenTelemetry tracing is disabled (OTEL_ENABLED=0)")
+        return
+
+    if _tracer_provider_configured():
+        _logger.info("OpenTelemetry tracer provider is already configured")
+        _instrument_fastapi(app)
+        _instrument_httpx()
+        _instrument_sqlalchemy()
         return
 
     try:
@@ -41,22 +46,35 @@ def setup_tracing(app: FastAPI) -> None:
             ConsoleSpanExporter,
         )
         from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+        from app.core.file_trace_exporter import JsonlSpanExporter
     except ImportError as exc:
-        _logger.warning("OpenTelemetry dependencies not installed: %s; tracing disabled", exc)
+        _logger.warning(
+            "OpenTelemetry dependencies not installed: %s; tracing disabled", exc
+        )
         return
 
     sample_rate = max(0.0, min(1.0, settings.otel_sample_rate))
+    service_name = os.getenv("THESIS_SERVICE_NAME", TRACER_NAME)
 
-    resource = Resource.create({"service.name": TRACER_NAME})
-
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.version": settings.app_version,
+            "deployment.environment": settings.environment,
+        }
+    )
     provider = TracerProvider(
         resource=resource,
         sampler=TraceIdRatioBased(sample_rate),
     )
 
-    console_exporter = ConsoleSpanExporter()
-    processor = BatchSpanProcessor(console_exporter)
-    provider.add_span_processor(processor)
+    file_exporter = JsonlSpanExporter(service_name=service_name)
+    provider.add_span_processor(BatchSpanProcessor(file_exporter))
+    _logger.info("Local trace export configured at %s", file_exporter.path)
+
+    if os.getenv("OTEL_CONSOLE_EXPORT", "0") not in {"0", "false", "False", ""}:
+        provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 
     if settings.otel_exporter_endpoint:
         try:
@@ -64,14 +82,18 @@ def setup_tracing(app: FastAPI) -> None:
                 OTLPSpanExporter,
             )
 
-            otlp_exporter = OTLPSpanExporter(
-                endpoint=settings.otel_exporter_endpoint,
+            provider.add_span_processor(
+                BatchSpanProcessor(
+                    OTLPSpanExporter(endpoint=settings.otel_exporter_endpoint)
+                )
             )
-            otlp_processor = BatchSpanProcessor(otlp_exporter)
-            provider.add_span_processor(otlp_processor)
-            _logger.info("OTLP exporter configured at %s", settings.otel_exporter_endpoint)
+            _logger.info(
+                "OTLP exporter configured at %s", settings.otel_exporter_endpoint
+            )
         except ImportError:
-            _logger.warning("OTLP exporter not installed; only console export active")
+            _logger.warning(
+                "OTLP exporter not installed; local file export remains active"
+            )
         except Exception as exc:
             _logger.warning("Failed to configure OTLP exporter: %s", exc)
 
@@ -83,13 +105,13 @@ def setup_tracing(app: FastAPI) -> None:
 
     _logger.info(
         "OpenTelemetry tracing enabled (service=%s sample_rate=%.2f)",
-        TRACER_NAME,
+        service_name,
         sample_rate,
     )
 
 
 def get_tracer(name: str = TRACER_NAME) -> Any:
-    """Get Tracer."""
+    """Return an OpenTelemetry tracer or a no-op fallback."""
     if not settings.otel_enabled:
         return _NoOpTracer()
 
@@ -103,41 +125,34 @@ def get_tracer(name: str = TRACER_NAME) -> Any:
 
 class _NoOpTracer:
     def start_as_current_span(self, name: str, *args: Any, **kwargs: Any) -> Any:
-        """Start As Current Span."""
+        """Return a no-op span context manager."""
         return _NoOpSpan()
 
     def start_span(self, name: str, *args: Any, **kwargs: Any) -> Any:
-        """Start Span."""
+        """Return a no-op span."""
         return _NoOpSpan()
 
 
 class _NoOpSpan:
     def __enter__(self) -> _NoOpSpan:
-        """Context manager enter."""
         return self
 
     def __exit__(self, *args: Any) -> None:
-        """Context manager exit."""
-        pass
+        return None
 
     def set_attribute(self, key: str, value: Any) -> None:
-        """Set Attribute."""
-        pass
+        return None
 
     def set_status(self, status: Any, description: str | None = None) -> None:
-        """Set Status."""
-        pass
+        return None
 
     def record_exception(self, exception: Exception) -> None:
-        """Record Exception."""
-        pass
+        return None
 
     def add_event(self, name: str, attributes: Any = None) -> None:
-        """Add Event."""
-        pass
+        return None
 
     def get_span_context(self) -> Any:
-        """Get Span Context."""
         return _NoOpSpanContext()
 
 
@@ -153,7 +168,7 @@ def _instrument_fastapi(app: FastAPI) -> None:
 
         FastAPIInstrumentor.instrument_app(
             app,
-            excluded_urls="/health,/favicon.ico,/static/*",
+            excluded_urls="/health,/favicon.ico,/static/*,/debug/observability/health",
         )
         _logger.info("FastAPI instrumentation applied")
     except Exception as exc:
@@ -172,9 +187,7 @@ def _instrument_httpx() -> None:
 
 def _instrument_sqlalchemy() -> None:
     try:
-        from opentelemetry.instrumentation.sqlalchemy import (
-            SQLAlchemyInstrumentor,
-        )
+        from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 
         SQLAlchemyInstrumentor().instrument(
             enable_commenter=True,

--- a/backend/app/embedding_service.py
+++ b/backend/app/embedding_service.py
@@ -1,7 +1,8 @@
-"""Embedding Service."""
+"""Dedicated embedding service with lightweight resource evidence."""
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from importlib import import_module
@@ -18,6 +19,7 @@ from app.core.process_limits import (
     get_open_file_descriptor_count,
     raise_nofile_soft_limit,
 )
+from app.services.resource_monitor import ResourceMonitor
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
@@ -28,11 +30,12 @@ logger = get_logger("embedding_service")
 
 _model_lock = Lock()
 _embedding_model: SentenceTransformer | None = None
+resource_monitor = ResourceMonitor(service_name="embedding-worker")
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Lifespan."""
+    """Start resource sampling before model load and stop it on shutdown."""
     raise_nofile_soft_limit(logger)
     soft_nofile, hard_nofile = get_nofile_limits()
     logger.info(
@@ -41,8 +44,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         soft_nofile,
         hard_nofile,
     )
-    _get_embedding_model()
-    yield
+    resource_monitor.start()
+    load_started = time.perf_counter()
+    try:
+        _get_embedding_model()
+        resource_monitor.record_operation(
+            "model_load",
+            duration_ms=(time.perf_counter() - load_started) * 1000,
+            details={"model": settings.embedding_model_name},
+        )
+        yield
+    finally:
+        resource_monitor.stop()
 
 
 app = FastAPI(
@@ -56,14 +69,14 @@ app = FastAPI(
 
 
 class EmbedRequest(BaseModel):
-    """Embed Request."""
+    """Embedding request."""
 
     texts: list[str] = Field(default_factory=list)
     batch_size: int = Field(default=32, ge=1, le=256)
 
 
 class EmbedResponse(BaseModel):
-    """Embed Response."""
+    """Embedding response."""
 
     embeddings: list[list[float]]
     model: str
@@ -102,32 +115,65 @@ def _get_embedding_model() -> SentenceTransformer:
 
 @app.get("/health")
 def health() -> dict[str, object]:
-    """Health."""
+    """Return model and resource-monitor health."""
     return {
         "ok": True,
         "model": settings.embedding_model_name,
         "loaded": _embedding_model is not None,
+        "resource_monitor_running": resource_monitor.running,
     }
+
+
+@app.get("/debug/resources")
+def resources() -> dict[str, object]:
+    """Return a current resource snapshot for direct worker diagnosis."""
+    return resource_monitor.collect_snapshot()
 
 
 @app.post("/embed", response_model=EmbedResponse)
 def embed(request: EmbedRequest) -> EmbedResponse:
-    """Embed."""
+    """Generate embeddings and record batch-level evidence."""
     if not request.texts:
         raise HTTPException(status_code=400, detail="texts must not be empty")
 
-    model = _get_embedding_model()
-    embeddings_array = model.encode(
-        request.texts,
-        batch_size=request.batch_size,
-        convert_to_numpy=True,
-        show_progress_bar=False,
-    )
-    embeddings = cast(list[list[float]], embeddings_array.tolist())
-    dimension = len(embeddings[0]) if embeddings else 0
-    return EmbedResponse(
-        embeddings=embeddings,
-        model=settings.embedding_model_name,
-        count=len(embeddings),
-        dimension=dimension,
-    )
+    started = time.perf_counter()
+    try:
+        model = _get_embedding_model()
+        embeddings_array = model.encode(
+            request.texts,
+            batch_size=request.batch_size,
+            convert_to_numpy=True,
+            show_progress_bar=False,
+        )
+        embeddings = cast(list[list[float]], embeddings_array.tolist())
+        dimension = len(embeddings[0]) if embeddings else 0
+        response = EmbedResponse(
+            embeddings=embeddings,
+            model=settings.embedding_model_name,
+            count=len(embeddings),
+            dimension=dimension,
+        )
+        resource_monitor.record_operation(
+            "embedding_batch",
+            duration_ms=(time.perf_counter() - started) * 1000,
+            details={
+                "input_count": len(request.texts),
+                "batch_size": request.batch_size,
+                "output_count": response.count,
+                "dimension": response.dimension,
+                "input_characters": sum(len(text) for text in request.texts),
+            },
+        )
+        return response
+    except Exception:
+        resource_monitor.record_operation(
+            "embedding_batch",
+            duration_ms=(time.perf_counter() - started) * 1000,
+            result="error",
+            details={
+                "input_count": len(request.texts),
+                "batch_size": request.batch_size,
+                "input_characters": sum(len(text) for text in request.texts),
+            },
+        )
+        raise

--- a/backend/app/middleware/request_tracing.py
+++ b/backend/app/middleware/request_tracing.py
@@ -44,9 +44,8 @@ class RequestTracingMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        request_id = (
-            request.headers.get("X-Request-ID") or f"req_{uuid.uuid4().hex[:12]}"
-        )
+        """Trace one request and attach correlation and timing headers."""
+        request_id = request.headers.get("X-Request-ID") or f"req_{uuid.uuid4().hex[:12]}"
         request.state.request_id = request_id
 
         path = request.url.path

--- a/backend/app/middleware/request_tracing.py
+++ b/backend/app/middleware/request_tracing.py
@@ -1,8 +1,4 @@
-"""Request Tracing Middleware.
-
-Automatically traces all requests through the system, capturing timing,
-errors, and correlating with stream events.
-"""
+"""Request correlation and structured timing middleware."""
 
 from __future__ import annotations
 
@@ -14,38 +10,53 @@ from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.core.logging import get_logger
-from app.services.debug_logger import debug_logger, EventType
+from app.services.debug_logger import EventType, debug_logger
 
 logger = get_logger("request_tracing")
-SKIP_TRACE_PREFIXES = ("/health", "/favicon.ico", "/static/")
+SKIP_TRACE_PREFIXES = (
+    "/health",
+    "/favicon.ico",
+    "/static/",
+    "/debug/observability/health",
+)
+
+
+def _current_trace_id(request_id: str) -> str | None:
+    """Attach the request ID to the current OTel span and return its trace ID."""
+    try:
+        from opentelemetry.trace import format_trace_id, get_current_span
+
+        span = get_current_span()
+        context = span.get_span_context()
+        if not context.trace_id:
+            return None
+        span.set_attribute("thesis.request_id", request_id)
+        return format_trace_id(context.trace_id)
+    except Exception:
+        return None
 
 
 class RequestTracingMiddleware(BaseHTTPMiddleware):
-    """Middleware that traces all HTTP requests."""
+    """Correlate requests with structured logs and optional OpenTelemetry spans."""
 
     async def dispatch(
         self,
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        """Dispatch."""
-        # Generate or extract request ID
-        request_id = request.headers.get("X-Request-ID") or f"req_{uuid.uuid4().hex[:12]}"
-
-        # Store request ID in state for access by route handlers
+        request_id = (
+            request.headers.get("X-Request-ID") or f"req_{uuid.uuid4().hex[:12]}"
+        )
         request.state.request_id = request_id
 
-        # Start tracing
         path = request.url.path
         method = request.method
-
-        # Skip tracing for health checks and static assets
         should_trace = not path.startswith(SKIP_TRACE_PREFIXES)
+        trace_id = _current_trace_id(request_id)
+        request.state.trace_id = trace_id
 
         if should_trace:
             debug_logger.start_request(request_id, path, method)
-
-            # Log query params and headers for debugging
             debug_logger.log_event(
                 EventType.CUSTOM,
                 component="request",
@@ -53,17 +64,19 @@ class RequestTracingMiddleware(BaseHTTPMiddleware):
                 message="Request details",
                 request_id=request_id,
                 details={
-                    "query_params": dict(request.query_params),
-                    "user_agent": request.headers.get("User-Agent", "unknown")[:100],
+                    "trace_id": trace_id,
+                    # Keep names for reproducibility without persisting query values.
+                    "query_param_names": sorted(set(request.query_params.keys())),
+                    "user_agent": request.headers.get("User-Agent", "unknown")[:160],
                     "content_type": request.headers.get("Content-Type"),
                     "accept": request.headers.get("Accept"),
                 },
             )
 
-        start_time = time.time()
-        error = None
+        start_time = time.perf_counter()
+        error: Exception | None = None
         status_code = 500
-        response = None
+        response: Response | None = None
 
         try:
             response = await call_next(request)
@@ -73,23 +86,24 @@ class RequestTracingMiddleware(BaseHTTPMiddleware):
             error = exc
             raise
         finally:
-            duration_ms = (time.time() - start_time) * 1000
+            duration_ms = (time.perf_counter() - start_time) * 1000
 
             if should_trace:
                 debug_logger.end_request(request_id, status_code, error)
-
-                # Log slow requests
-                if duration_ms > 5000:  # 5 seconds
+                if duration_ms > 5000:
                     logger.warning(
-                        "Slow request detected: %s %s took %.1fms",
+                        "Slow request detected: %s %s took %.1fms request_id=%s trace_id=%s",
                         method,
                         path,
                         duration_ms,
+                        request_id,
+                        trace_id,
                     )
 
-            # Add headers to response if we have one
             if response is not None:
                 response.headers["X-Request-ID"] = request_id
+                if trace_id:
+                    response.headers["X-Trace-ID"] = trace_id
                 response.headers["X-Response-Time"] = f"{duration_ms:.1f}ms"
                 response.headers["Server-Timing"] = f"app;dur={duration_ms:.1f}"
 
@@ -97,3 +111,8 @@ class RequestTracingMiddleware(BaseHTTPMiddleware):
 def get_request_id(request: Request) -> str:
     """Get the request ID from request state."""
     return getattr(request.state, "request_id", "unknown")
+
+
+def get_trace_id(request: Request) -> str | None:
+    """Get the current OpenTelemetry trace ID from request state."""
+    return getattr(request.state, "trace_id", None)

--- a/backend/app/services/debug_logger.py
+++ b/backend/app/services/debug_logger.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any
 from collections.abc import Iterator
 
+from app.core.jsonl import append_jsonl
 from app.core.logging import get_logger
 
 logger = get_logger("debug_logger")
@@ -198,11 +199,12 @@ class DebugLoggerService:
     def __init__(self) -> None:
         """Initialize."""
         self._lock = threading.Lock()
+        self._file_lock = threading.Lock()
         self._events: deque[DebugEvent] = deque(maxlen=MAX_IN_MEMORY_EVENTS)
         self._active_requests: dict[str, RequestTrace] = {}
         self._active_streams: dict[str, StreamTrace] = {}
         self._log_file: Path | None = None
-        self._session_id = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        self._session_id = f"{datetime.now(UTC):%Y%m%d_%H%M%S}_{os.getpid()}"
         self._event_counter = 0
         self._frontend_reports: deque[dict[str, Any]] = deque(maxlen=20)
 
@@ -229,7 +231,8 @@ class DebugLoggerService:
             "timestamp": datetime.now(UTC).isoformat(),
             "thresholds": THRESHOLDS,
         }
-        self._log_file.open("w").write(json.dumps(header) + "\n")
+        self._log_file.unlink(missing_ok=True)
+        append_jsonl(self._log_file, header)
 
     def _generate_event_id(self) -> str:
         """Generate a unique event ID."""
@@ -241,7 +244,8 @@ class DebugLoggerService:
         """Write event to log file."""
         if self._log_file:
             try:
-                self._log_file.open("a").write(event.to_json() + "\n")
+                with self._file_lock:
+                    append_jsonl(self._log_file, event.to_dict())
             except Exception as e:
                 if isinstance(e, OSError) and e.errno == 24:
                     logger.error(

--- a/backend/app/services/resource_monitor.py
+++ b/backend/app/services/resource_monitor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import heapq
 import json
 import os
 import shutil
@@ -15,6 +16,7 @@ from typing import Any
 
 import psutil
 
+from app.core.jsonl import append_jsonl
 from app.core.logging import get_logger, get_runtime_log_dir
 
 logger = get_logger("resource_monitor")
@@ -68,9 +70,7 @@ def _parse_gpu_rows(output: str) -> list[dict[str, Any]]:
                 "index": int(index) if index.isdigit() else index,
                 "name": name,
                 "utilization_percent": as_float(utilization),
-                "memory_used_bytes": int(used_mib * 1024 * 1024)
-                if used_mib is not None
-                else None,
+                "memory_used_bytes": int(used_mib * 1024 * 1024) if used_mib is not None else None,
                 "memory_total_bytes": int(total_mib * 1024 * 1024)
                 if total_mib is not None
                 else None,
@@ -87,9 +87,7 @@ def collect_gpu_snapshot(timeout_seconds: float = 1.5) -> list[dict[str, Any]]:
     if executable is None:
         return []
 
-    query = (
-        "index,name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw"
-    )
+    query = "index,name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw"
     try:
         result = subprocess.run(
             [
@@ -114,7 +112,10 @@ def read_jsonl_records(
     since: datetime | None = None,
 ) -> list[dict[str, Any]]:
     """Read and time-sort JSONL records from one or more files."""
-    records: list[dict[str, Any]] = []
+    if limit <= 0:
+        return []
+    records: list[tuple[str, int, dict[str, Any]]] = []
+    sequence = 0
     for path in paths:
         if not path.exists() or not path.is_file():
             continue
@@ -132,9 +133,7 @@ def read_jsonl_records(
                     timestamp = value.get("timestamp")
                     if since is not None and isinstance(timestamp, str):
                         try:
-                            parsed = datetime.fromisoformat(
-                                timestamp.replace("Z", "+00:00")
-                            )
+                            parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
                         except ValueError:
                             parsed = None
                         if parsed is not None:
@@ -142,12 +141,17 @@ def read_jsonl_records(
                                 parsed = parsed.replace(tzinfo=UTC)
                             if parsed < since:
                                 continue
-                    records.append(value)
+                    entry = (str(value.get("timestamp", "")), sequence, value)
+                    sequence += 1
+                    if len(records) < limit:
+                        heapq.heappush(records, entry)
+                    elif entry > records[0]:
+                        heapq.heapreplace(records, entry)
         except OSError:
             continue
 
-    records.sort(key=lambda item: str(item.get("timestamp", "")))
-    return records[-limit:]
+    records.sort()
+    return [record for _, _, record in records]
 
 
 class ResourceMonitor:
@@ -160,7 +164,9 @@ class ResourceMonitor:
         interval_seconds: float | None = None,
         log_dir: Path | None = None,
     ) -> None:
-        self.service_name = service_name or os.getenv("THESIS_SERVICE_NAME", "backend")
+        """Configure one process-local sampler and its bounded JSONL path."""
+        resolved_service_name = service_name or os.environ.get("THESIS_SERVICE_NAME") or "backend"
+        self.service_name: str = resolved_service_name
         raw_interval = interval_seconds or float(
             os.getenv("THESIS_PERFORMANCE_SAMPLE_SECONDS", "5")
         )
@@ -188,9 +194,11 @@ class ResourceMonitor:
 
     @property
     def running(self) -> bool:
+        """Return whether the sampler thread is active."""
         return self._thread is not None and self._thread.is_alive()
 
     def set_event_loop_lag(self, lag_ms: float) -> None:
+        """Store the most recent event-loop delay for the next sample."""
         with self._state_lock:
             self._event_loop_lag_ms = max(0.0, lag_ms)
 
@@ -228,9 +236,7 @@ class ResourceMonitor:
                 "cpu_percent": psutil.cpu_percent(interval=None),
                 "cpu_count_logical": psutil.cpu_count(logical=True),
                 "cpu_count_physical": psutil.cpu_count(logical=False),
-                "load_average": list(os.getloadavg())
-                if hasattr(os, "getloadavg")
-                else None,
+                "load_average": list(os.getloadavg()) if hasattr(os, "getloadavg") else None,
                 "memory_total_bytes": virtual_memory.total,
                 "memory_available_bytes": virtual_memory.available,
                 "memory_used_percent": virtual_memory.percent,
@@ -260,20 +266,18 @@ class ResourceMonitor:
         return snapshot
 
     def latest_snapshot(self) -> dict[str, Any]:
+        """Return the most recent sample or collect one when none exists."""
         with self._state_lock:
             latest = self._latest
         return latest or self.collect_snapshot()
 
     def _append(self, snapshot: dict[str, Any]) -> None:
         self.log_dir.mkdir(parents=True, exist_ok=True)
-        serialized = json.dumps(snapshot, separators=(",", ":"), default=str)
         try:
-            with self._write_lock, self.log_path.open("a", encoding="utf-8") as handle:
-                handle.write(serialized + "\n")
+            with self._write_lock:
+                append_jsonl(self.log_path, snapshot)
         except OSError as exc:
-            logger.warning(
-                "Could not write performance sample to %s: %s", self.log_path, exc
-            )
+            logger.warning("Could not write performance sample to %s: %s", self.log_path, exc)
 
     def record_operation(
         self,

--- a/backend/app/services/resource_monitor.py
+++ b/backend/app/services/resource_monitor.py
@@ -1,0 +1,336 @@
+"""Lightweight resource sampling for agent-readable performance evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+from app.core.logging import get_logger, get_runtime_log_dir
+
+logger = get_logger("resource_monitor")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _safe_call(default: Any, callback: Any) -> Any:
+    try:
+        return callback()
+    except (
+        AttributeError,
+        OSError,
+        PermissionError,
+        RuntimeError,
+        ValueError,
+        psutil.Error,
+    ):
+        return default
+
+
+def _number(value: Any) -> int | float | None:
+    return value if isinstance(value, (int, float)) else None
+
+
+def _parse_gpu_rows(output: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        fields = [field.strip() for field in line.split(",")]
+        if len(fields) != 7:
+            continue
+        index, name, utilization, memory_used, memory_total, temperature, power = fields
+
+        def as_float(raw: str) -> float | None:
+            if raw in {"", "N/A", "[Not Supported]"}:
+                return None
+            try:
+                return float(raw)
+            except ValueError:
+                return None
+
+        used_mib = as_float(memory_used)
+        total_mib = as_float(memory_total)
+        rows.append(
+            {
+                "index": int(index) if index.isdigit() else index,
+                "name": name,
+                "utilization_percent": as_float(utilization),
+                "memory_used_bytes": int(used_mib * 1024 * 1024)
+                if used_mib is not None
+                else None,
+                "memory_total_bytes": int(total_mib * 1024 * 1024)
+                if total_mib is not None
+                else None,
+                "temperature_celsius": as_float(temperature),
+                "power_watts": as_float(power),
+            }
+        )
+    return rows
+
+
+def collect_gpu_snapshot(timeout_seconds: float = 1.5) -> list[dict[str, Any]]:
+    """Collect NVIDIA GPU state when nvidia-smi is available."""
+    executable = shutil.which("nvidia-smi")
+    if executable is None:
+        return []
+
+    query = (
+        "index,name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw"
+    )
+    try:
+        result = subprocess.run(
+            [
+                executable,
+                f"--query-gpu={query}",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return _parse_gpu_rows(result.stdout)
+
+
+def read_jsonl_records(
+    paths: Iterable[Path],
+    *,
+    limit: int = 200,
+    since: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Read and time-sort JSONL records from one or more files."""
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            with path.open(encoding="utf-8") as handle:
+                for line in handle:
+                    if not line.strip():
+                        continue
+                    try:
+                        value = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(value, dict):
+                        continue
+                    timestamp = value.get("timestamp")
+                    if since is not None and isinstance(timestamp, str):
+                        try:
+                            parsed = datetime.fromisoformat(
+                                timestamp.replace("Z", "+00:00")
+                            )
+                        except ValueError:
+                            parsed = None
+                        if parsed is not None:
+                            if parsed.tzinfo is None:
+                                parsed = parsed.replace(tzinfo=UTC)
+                            if parsed < since:
+                                continue
+                    records.append(value)
+        except OSError:
+            continue
+
+    records.sort(key=lambda item: str(item.get("timestamp", "")))
+    return records[-limit:]
+
+
+class ResourceMonitor:
+    """Sample host, process, disk, network, and optional GPU state to JSONL."""
+
+    def __init__(
+        self,
+        *,
+        service_name: str | None = None,
+        interval_seconds: float | None = None,
+        log_dir: Path | None = None,
+    ) -> None:
+        self.service_name = service_name or os.getenv("THESIS_SERVICE_NAME", "backend")
+        raw_interval = interval_seconds or float(
+            os.getenv("THESIS_PERFORMANCE_SAMPLE_SECONDS", "5")
+        )
+        self.interval_seconds = max(1.0, raw_interval)
+        self.log_dir = log_dir or get_runtime_log_dir()
+        safe_service = "".join(
+            character if character.isalnum() or character in {"-", "_"} else "_"
+            for character in self.service_name
+        )
+        self.log_path = self.log_dir / f"performance_{safe_service}_{os.getpid()}.jsonl"
+        self._process = psutil.Process(os.getpid())
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._write_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._latest: dict[str, Any] | None = None
+        self._event_loop_lag_ms: float | None = None
+        self._enabled = os.getenv("THESIS_OBSERVABILITY_ENABLED", "1") not in {
+            "0",
+            "false",
+            "False",
+            "",
+        }
+        _safe_call(0.0, lambda: self._process.cpu_percent(interval=None))
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def set_event_loop_lag(self, lag_ms: float) -> None:
+        with self._state_lock:
+            self._event_loop_lag_ms = max(0.0, lag_ms)
+
+    def collect_snapshot(self) -> dict[str, Any]:
+        """Collect one resource snapshot without writing it."""
+        memory = _safe_call(None, self._process.memory_info)
+        process_io = _safe_call(None, self._process.io_counters)
+        virtual_memory = psutil.virtual_memory()
+        swap_memory = psutil.swap_memory()
+        disk_io = psutil.disk_io_counters()
+        network_io = psutil.net_io_counters()
+        disk_usage = psutil.disk_usage(str(self.log_dir.anchor or "/"))
+
+        with self._state_lock:
+            event_loop_lag_ms = self._event_loop_lag_ms
+
+        snapshot: dict[str, Any] = {
+            "timestamp": _utc_now(),
+            "kind": "resource_sample",
+            "service": self.service_name,
+            "pid": os.getpid(),
+            "process": {
+                "cpu_percent": _number(
+                    _safe_call(None, lambda: self._process.cpu_percent(interval=None))
+                ),
+                "rss_bytes": getattr(memory, "rss", None),
+                "vms_bytes": getattr(memory, "vms", None),
+                "thread_count": _safe_call(None, self._process.num_threads),
+                "open_file_descriptors": _safe_call(None, self._process.num_fds),
+                "read_bytes": getattr(process_io, "read_bytes", None),
+                "write_bytes": getattr(process_io, "write_bytes", None),
+                "event_loop_lag_ms": event_loop_lag_ms,
+            },
+            "system": {
+                "cpu_percent": psutil.cpu_percent(interval=None),
+                "cpu_count_logical": psutil.cpu_count(logical=True),
+                "cpu_count_physical": psutil.cpu_count(logical=False),
+                "load_average": list(os.getloadavg())
+                if hasattr(os, "getloadavg")
+                else None,
+                "memory_total_bytes": virtual_memory.total,
+                "memory_available_bytes": virtual_memory.available,
+                "memory_used_percent": virtual_memory.percent,
+                "swap_used_bytes": swap_memory.used,
+                "swap_used_percent": swap_memory.percent,
+            },
+            "disk": {
+                "total_bytes": disk_usage.total,
+                "used_bytes": disk_usage.used,
+                "free_bytes": disk_usage.free,
+                "used_percent": disk_usage.percent,
+                "read_bytes": getattr(disk_io, "read_bytes", None),
+                "write_bytes": getattr(disk_io, "write_bytes", None),
+                "read_count": getattr(disk_io, "read_count", None),
+                "write_count": getattr(disk_io, "write_count", None),
+            },
+            "network": {
+                "bytes_sent": getattr(network_io, "bytes_sent", None),
+                "bytes_received": getattr(network_io, "bytes_recv", None),
+                "packets_sent": getattr(network_io, "packets_sent", None),
+                "packets_received": getattr(network_io, "packets_recv", None),
+            },
+            "gpus": collect_gpu_snapshot(),
+        }
+        with self._state_lock:
+            self._latest = snapshot
+        return snapshot
+
+    def latest_snapshot(self) -> dict[str, Any]:
+        with self._state_lock:
+            latest = self._latest
+        return latest or self.collect_snapshot()
+
+    def _append(self, snapshot: dict[str, Any]) -> None:
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(snapshot, separators=(",", ":"), default=str)
+        try:
+            with self._write_lock, self.log_path.open("a", encoding="utf-8") as handle:
+                handle.write(serialized + "\n")
+        except OSError as exc:
+            logger.warning(
+                "Could not write performance sample to %s: %s", self.log_path, exc
+            )
+
+    def record_operation(
+        self,
+        operation: str,
+        *,
+        duration_ms: float | None = None,
+        result: str = "success",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Append a sparse operation event beside periodic resource samples."""
+        self._append(
+            {
+                "timestamp": _utc_now(),
+                "kind": "operation",
+                "service": self.service_name,
+                "pid": os.getpid(),
+                "operation": operation,
+                "duration_ms": duration_ms,
+                "result": result,
+                "details": details or {},
+            }
+        )
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            started = time.monotonic()
+            try:
+                self._append(self.collect_snapshot())
+            except Exception as exc:  # pragma: no cover - defensive monitor isolation
+                logger.warning("Resource sampling failed: %s", exc, exc_info=True)
+            remaining = max(0.0, self.interval_seconds - (time.monotonic() - started))
+            self._stop_event.wait(remaining)
+
+    def start(self) -> None:
+        """Start the daemon sampler when observability is enabled."""
+        if not self._enabled or self.running:
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"resource-monitor-{self.service_name}",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Resource monitor started (service=%s interval=%.1fs path=%s)",
+            self.service_name,
+            self.interval_seconds,
+            self.log_path,
+        )
+
+    def stop(self) -> None:
+        """Stop the sampler and wait briefly for the thread to exit."""
+        self._stop_event.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=max(2.0, self.interval_seconds + 1.0))
+        self._thread = None
+
+
+resource_monitor = ResourceMonitor()

--- a/backend/tests/test_debug_bundle_script.py
+++ b/backend/tests/test_debug_bundle_script.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "collect_debug_bundle.py"
+)
+SPEC = importlib.util.spec_from_file_location("collect_debug_bundle", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+bundle = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bundle)
+
+
+def test_parse_duration() -> None:
+    assert bundle.parse_duration("30m") == timedelta(minutes=30)
+    assert bundle.parse_duration("2h") == timedelta(hours=2)
+
+
+def test_sanitize_database_url() -> None:
+    value = bundle.sanitize_value(
+        "DATABASE_URL",
+        "postgresql://newsuser:secret@localhost:5432/newsdb",
+    )
+    assert value == "postgresql://newsuser:<redacted>@localhost:5432/newsdb"
+
+
+def test_filter_jsonl_keeps_selected_time_window(tmp_path: Path) -> None:
+    source = tmp_path / "source.jsonl"
+    destination = tmp_path / "bundle" / "source.jsonl"
+    now = datetime.now(UTC)
+    source.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {"timestamp": (now - timedelta(hours=2)).isoformat(), "id": 1}
+                ),
+                json.dumps({"timestamp": now.isoformat(), "id": 2}),
+                "not-json",
+            ]
+        )
+        + "\n"
+    )
+
+    result = bundle.filter_jsonl(
+        source,
+        destination,
+        now - timedelta(minutes=30),
+    )
+
+    assert result["kept_records"] == 1
+    assert result["malformed_records"] == 1
+    assert json.loads(destination.read_text())["id"] == 2

--- a/backend/tests/test_debug_bundle_script.py
+++ b/backend/tests/test_debug_bundle_script.py
@@ -5,9 +5,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-SCRIPT_PATH = (
-    Path(__file__).resolve().parents[2] / "scripts" / "collect_debug_bundle.py"
-)
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "collect_debug_bundle.py"
 SPEC = importlib.util.spec_from_file_location("collect_debug_bundle", SCRIPT_PATH)
 assert SPEC is not None and SPEC.loader is not None
 bundle = importlib.util.module_from_spec(SPEC)
@@ -27,6 +25,26 @@ def test_sanitize_database_url() -> None:
     assert value == "postgresql://newsuser:<redacted>@localhost:5432/newsdb"
 
 
+def test_sanitize_record_redacts_nested_secrets_and_url_values() -> None:
+    value = bundle.sanitize_record(
+        {
+            "authorization": "Bearer secret-value",
+            "details": {
+                "message": "token=abc123 url=https://example.test/path?q=private",
+                "database": "postgresql://user:pass@example.test/db",
+            },
+        }
+    )
+
+    assert value == {
+        "authorization": "<redacted>",
+        "details": {
+            "message": ("token=<redacted> url=https://example.test/path?q=<redacted>"),
+            "database": "postgresql://user:<redacted>@example.test/db",
+        },
+    }
+
+
 def test_filter_jsonl_keeps_selected_time_window(tmp_path: Path) -> None:
     source = tmp_path / "source.jsonl"
     destination = tmp_path / "bundle" / "source.jsonl"
@@ -34,9 +52,7 @@ def test_filter_jsonl_keeps_selected_time_window(tmp_path: Path) -> None:
     source.write_text(
         "\n".join(
             [
-                json.dumps(
-                    {"timestamp": (now - timedelta(hours=2)).isoformat(), "id": 1}
-                ),
+                json.dumps({"timestamp": (now - timedelta(hours=2)).isoformat(), "id": 1}),
                 json.dumps({"timestamp": now.isoformat(), "id": 2}),
                 "not-json",
             ]

--- a/backend/tests/test_file_trace_exporter.py
+++ b/backend/tests/test_file_trace_exporter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from app.core.file_trace_exporter import JsonlSpanExporter
+
+
+def test_jsonl_span_exporter_persists_correlation_attributes(tmp_path: Path) -> None:
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": "test-service"})
+    )
+    exporter = JsonlSpanExporter(service_name="test-service", log_dir=tmp_path)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+
+    with tracer.start_as_current_span("database.fetch_articles") as span:
+        span.set_attribute("thesis.request_id", "req_test")
+
+    provider.shutdown()
+    record = json.loads(exporter.path.read_text().strip())
+    assert record["kind"] == "trace_span"
+    assert record["service"] == "test-service"
+    assert record["operation"] == "database.fetch_articles"
+    assert record["attributes"]["thesis.request_id"] == "req_test"
+    assert len(record["trace_id"]) == 32
+    assert len(record["span_id"]) == 16

--- a/backend/tests/test_file_trace_exporter.py
+++ b/backend/tests/test_file_trace_exporter.py
@@ -11,9 +11,7 @@ from app.core.file_trace_exporter import JsonlSpanExporter
 
 
 def test_jsonl_span_exporter_persists_correlation_attributes(tmp_path: Path) -> None:
-    provider = TracerProvider(
-        resource=Resource.create({"service.name": "test-service"})
-    )
+    provider = TracerProvider(resource=Resource.create({"service.name": "test-service"}))
     exporter = JsonlSpanExporter(service_name="test-service", log_dir=tmp_path)
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     tracer = provider.get_tracer("test")

--- a/backend/tests/test_jsonl.py
+++ b/backend/tests/test_jsonl.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.core.jsonl import append_jsonl, sanitize_runtime_value
+
+
+def test_sanitize_runtime_value_redacts_nested_secrets() -> None:
+    assert sanitize_runtime_value(
+        {
+            "authorization": "Bearer abc",
+            "url": "https://user:pass@example.test/path?q=private",
+            "message": "token=abc123",
+            "monkey_count": 4,
+        }
+    ) == {
+        "authorization": "<redacted>",
+        "url": "https://user:<redacted>@example.test/path?q=<redacted>",
+        "message": "token=<redacted>",
+        "monkey_count": 4,
+    }
+
+
+def test_append_jsonl_rotates_before_size_cap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("THESIS_LOG_MAX_BYTES", "80")
+    monkeypatch.setenv("THESIS_LOG_BACKUP_COUNT", "2")
+    path = tmp_path / "events.jsonl"
+
+    for index in range(5):
+        append_jsonl(path, {"index": index, "message": "x" * 24})
+
+    rotated = tmp_path / "events.1.jsonl"
+    assert path.exists()
+    assert rotated.exists()
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    assert records[-1]["index"] == 4
+    assert not (tmp_path / "events.3.jsonl").exists()

--- a/backend/tests/test_resource_monitor.py
+++ b/backend/tests/test_resource_monitor.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from app.services.resource_monitor import (
+    ResourceMonitor,
+    _parse_gpu_rows,
+    read_jsonl_records,
+)
+
+
+def test_parse_gpu_rows_converts_mib_to_bytes() -> None:
+    rows = _parse_gpu_rows("0, NVIDIA RTX, 84, 1024, 12288, 71, 120.5\n")
+
+    assert rows == [
+        {
+            "index": 0,
+            "name": "NVIDIA RTX",
+            "utilization_percent": 84.0,
+            "memory_used_bytes": 1024 * 1024 * 1024,
+            "memory_total_bytes": 12288 * 1024 * 1024,
+            "temperature_celsius": 71.0,
+            "power_watts": 120.5,
+        }
+    ]
+
+
+def test_resource_monitor_writes_agent_readable_jsonl(tmp_path: Path) -> None:
+    monitor = ResourceMonitor(
+        service_name="test-service",
+        interval_seconds=1,
+        log_dir=tmp_path,
+    )
+
+    monitor.start()
+    deadline = time.monotonic() + 2
+    while not monitor.log_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    monitor.stop()
+
+    assert monitor.log_path.exists()
+    record = json.loads(monitor.log_path.read_text().splitlines()[0])
+    assert record["kind"] == "resource_sample"
+    assert record["service"] == "test-service"
+    assert record["process"]["rss_bytes"] > 0
+    assert record["system"]["memory_total_bytes"] > 0
+    assert "used_percent" in record["disk"]
+    assert isinstance(record["gpus"], list)
+
+
+def test_record_operation_is_sparse_and_correlatable(tmp_path: Path) -> None:
+    monitor = ResourceMonitor(service_name="embedding-worker", log_dir=tmp_path)
+    monitor.record_operation(
+        "embedding_batch",
+        duration_ms=123.4,
+        details={"input_count": 12, "batch_size": 4},
+    )
+
+    record = json.loads(monitor.log_path.read_text().strip())
+    assert record["kind"] == "operation"
+    assert record["operation"] == "embedding_batch"
+    assert record["duration_ms"] == 123.4
+    assert record["details"]["input_count"] == 12
+
+
+def test_read_jsonl_records_filters_by_time(tmp_path: Path) -> None:
+    path = tmp_path / "performance_test_1.jsonl"
+    old = datetime.now(UTC) - timedelta(hours=2)
+    recent = datetime.now(UTC)
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"timestamp": old.isoformat(), "value": "old"}),
+                json.dumps({"timestamp": recent.isoformat(), "value": "recent"}),
+            ]
+        )
+        + "\n"
+    )
+
+    records = read_jsonl_records(
+        [path],
+        since=datetime.now(UTC) - timedelta(minutes=30),
+    )
+    assert [record["value"] for record in records] == ["recent"]

--- a/backend/tests/test_resource_monitor.py
+++ b/backend/tests/test_resource_monitor.py
@@ -85,3 +85,26 @@ def test_read_jsonl_records_filters_by_time(tmp_path: Path) -> None:
         since=datetime.now(UTC) - timedelta(minutes=30),
     )
     assert [record["value"] for record in records] == ["recent"]
+
+
+def test_read_jsonl_records_keeps_only_latest_limit(tmp_path: Path) -> None:
+    first = tmp_path / "performance_a.jsonl"
+    second = tmp_path / "performance_b.jsonl"
+    first.write_text(
+        "\n".join(
+            json.dumps({"timestamp": f"2026-01-01T00:00:0{index}+00:00", "value": index})
+            for index in (1, 3)
+        )
+        + "\n"
+    )
+    second.write_text(
+        "\n".join(
+            json.dumps({"timestamp": f"2026-01-01T00:00:0{index}+00:00", "value": index})
+            for index in (2, 4)
+        )
+        + "\n"
+    )
+
+    records = read_jsonl_records([first, second], limit=2)
+
+    assert [record["value"] for record in records] == [3, 4]

--- a/debug-bundles/.gitignore
+++ b/debug-bundles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,14 @@ services:
     environment:
       - PYTHONPATH=/app
       - PYTHONUNBUFFERED=1
+      - THESIS_RUNTIME_DIR=/runtime-data
+      - THESIS_SERVICE_NAME=embedding-worker
+      - THESIS_OBSERVABILITY_ENABLED=1
+      - THESIS_PERFORMANCE_SAMPLE_SECONDS=5
+      - DEBUG_LOG_DIR=/runtime-data/logs/embedding-worker
+      - LOG_DIR=/runtime-data/logs/embedding-worker/sessions
+    volumes:
+      - ./runtime-data:/runtime-data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
       interval: 10s
@@ -68,7 +76,7 @@ services:
       - thesis_network
 
   backend:
-    build: 
+    build:
       context: .
       dockerfile: backend/Dockerfile
     ports:
@@ -82,8 +90,18 @@ services:
       - EMBEDDING_SERVICE_URL=http://embedding-worker:8002
       - CORS_ORIGINS=http://localhost:3000,http://localhost:3001,https://test.jordandgreen.com
       - CORS_ORIGIN_REGEX=^https://([a-z0-9-]+\.)?jordandgreen\.com$
+      - THESIS_RUNTIME_DIR=/runtime-data
+      - THESIS_SERVICE_NAME=backend
+      - THESIS_OBSERVABILITY_ENABLED=1
+      - THESIS_PERFORMANCE_SAMPLE_SECONDS=5
+      - DEBUG_LOG_DIR=/runtime-data/logs/backend
+      - LOG_DIR=/runtime-data/logs/backend/sessions
+      - OTEL_ENABLED=1
+      - OTEL_SAMPLE_RATE=1.0
+      - OTEL_CONSOLE_EXPORT=0
     volumes:
       - ./backend:/app
+      - ./runtime-data:/runtime-data
       - backend_cache:/app/.venv
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     restart: unless-stopped

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -1,5 +1,19 @@
 # Log
 
+## 2026-07-19 — Agent-Readable Debug Bundles
+
+- Added local structured resource samples, OpenTelemetry span files, browser error and timing capture, and correlated request and trace IDs.
+- Added `./scripts/collect-debug-bundle --since 30m` for time-filtered runtime, API, Git, and host evidence.
+- Bounded each runtime JSONL file to 25 MiB plus three rotating backups by default.
+- Redacted nested secret fields, URL credentials, and query values both when runtime evidence is written and when a bundle is built.
+- Moved file scanning and direct resource collection off the API event loop, and bounded recent-sample memory to the requested result limit.
+
+Verification:
+
+- Focused observability tests: 12 passed.
+- Router lifespan smoke: passed.
+- `scripts/self-test`: frontend build/typecheck/lint, strict backend mypy and Ruff, Rust Clippy/format/native binding build, and 449 backend tests passed; 3 slow tests were deselected.
+
 ## 2026-07-19 — Intelligence Atlas Review Fixes
 
 Repaired the Intelligence Atlas pull request before integration.

--- a/docs/agent-debugging.md
+++ b/docs/agent-debugging.md
@@ -1,0 +1,75 @@
+# Evidence-based debugging
+
+Thesis keeps a small local evidence layer so a coding agent can diagnose failures from facts instead of reconstructing them from a vague symptom.
+
+## What is collected
+
+Runtime data is written under `runtime-data/` by default. Override the location with `THESIS_RUNTIME_DIR`.
+
+- Existing structured application events remain JSONL and now default to `runtime-data/logs/`.
+- `performance_<service>_<pid>.jsonl` stores one resource sample every five seconds.
+- `traces_<service>_<pid>.jsonl` stores completed OpenTelemetry spans when `OTEL_ENABLED=1`.
+- Frontend errors, unhandled promise rejections, resource failures, navigation timing, and browser long tasks are sent to the existing `/debug/logs/frontend` endpoint.
+
+Resource samples include process and host CPU, process RSS/VMS, host memory and swap, disk usage and cumulative I/O, network counters, thread/file-descriptor counts, event-loop lag, and NVIDIA GPU state when `nvidia-smi` is available.
+
+The embedding worker also records sparse `model_load` and `embedding_batch` operation events. Those include duration, input count, batch size, character count, result count, and embedding dimension without storing input text.
+
+## Collect a bundle
+
+Reproduce the problem, then run:
+
+```bash
+./scripts/collect-debug-bundle --since 30m
+```
+
+The command prints a directory and ZIP path under `debug-bundles/`. It is best-effort: it still produces a bundle when the backend, Docker, Node, Postgres, or Chroma is unavailable.
+
+The bundle contains:
+
+- Time-filtered JSONL logs
+- Current and recent resource snapshots
+- Existing profiling, query, startup, pipeline, storage-drift, and debug reports
+- Git revision, branch, dirty state, and recent commits
+- Python, Node, platform, Docker Compose, disk, and sanitized configuration context
+- A deterministic `summary.md`
+
+Give an agent the repository, the user-visible symptom, and the generated ZIP. Correlate records using timestamps plus `service`, `operation`, `request_id`, and `trace_id`.
+
+## Useful endpoints
+
+```text
+GET /debug/observability/resources
+GET /debug/observability/performance?since_minutes=30&limit=500
+GET /debug/observability/runtime
+GET /debug/observability/health
+GET /debug/logs/report
+GET /profiling/summary
+GET /profiling/queries
+```
+
+The embedding worker also exposes `GET /debug/resources` on its own port.
+
+## Configuration
+
+```env
+THESIS_OBSERVABILITY_ENABLED=1
+THESIS_PERFORMANCE_SAMPLE_SECONDS=5
+THESIS_RUNTIME_DIR=/path/to/runtime-data
+THESIS_SERVICE_NAME=backend
+OTEL_ENABLED=1
+OTEL_SAMPLE_RATE=1.0
+OTEL_CONSOLE_EXPORT=0
+```
+
+OpenTelemetry remains optional. Resource sampling and structured request events do not require an external collector, Prometheus, Grafana, Loki, Tempo, or Pyroscope.
+
+## Privacy and size rules
+
+- Query parameter values are not recorded by request tracing; only parameter names are retained.
+- Browser telemetry records the pathname, not URL query strings.
+- Embedding text is never logged.
+- The bundle collector whitelists configuration keys and redacts secrets and database passwords.
+- Generated runtime data and bundles are ignored by Git.
+
+Use `py-spy`, `tracemalloc`, Playwright traces, or `EXPLAIN ANALYZE` only after the lightweight evidence identifies which service or operation needs deeper profiling.

--- a/docs/agent-debugging.md
+++ b/docs/agent-debugging.md
@@ -57,6 +57,8 @@ THESIS_OBSERVABILITY_ENABLED=1
 THESIS_PERFORMANCE_SAMPLE_SECONDS=5
 THESIS_RUNTIME_DIR=/path/to/runtime-data
 THESIS_SERVICE_NAME=backend
+THESIS_LOG_MAX_BYTES=26214400
+THESIS_LOG_BACKUP_COUNT=3
 OTEL_ENABLED=1
 OTEL_SAMPLE_RATE=1.0
 OTEL_CONSOLE_EXPORT=0
@@ -70,6 +72,7 @@ OpenTelemetry remains optional. Resource sampling and structured request events 
 - Browser telemetry records the pathname, not URL query strings.
 - Embedding text is never logged.
 - The bundle collector whitelists configuration keys and redacts secrets and database passwords.
+- Runtime JSONL files rotate at 25 MiB by default and retain three backups. Override the cap and backup count with `THESIS_LOG_MAX_BYTES` and `THESIS_LOG_BACKUP_COUNT`.
 - Generated runtime data and bundles are ignored by Git.
 
 Use `py-spy`, `tracemalloc`, Playwright traces, or `EXPLAIN ANALYZE` only after the lightweight evidence identifies which service or operation needs deeper profiling.

--- a/docs/agent/known-errors.md
+++ b/docs/agent/known-errors.md
@@ -1,5 +1,23 @@
 # Known Errors
 
+## Runtime evidence fills local storage
+
+Symptom:
+
+```txt
+Files under runtime-data/logs keep growing while observability or tracing runs.
+```
+
+Cause:
+
+- A JSONL writer appends resource samples, traces, or debug events without size-based rotation.
+
+Fix:
+
+- Write runtime records through `app.core.jsonl.append_jsonl`.
+- Keep `THESIS_LOG_MAX_BYTES` and `THESIS_LOG_BACKUP_COUNT` at bounded positive values. The defaults are 25 MiB and three backups.
+- Keep process IDs in per-process log names so workers do not rotate the same file.
+
 ## RSS refresh appears stuck before articles become visible
 
 Symptom:

--- a/docs/agent/learnings.md
+++ b/docs/agent/learnings.md
@@ -1,5 +1,21 @@
 # Learnings
 
+## 2026-07-19 — Durable debug evidence needs bounds and redaction at write time
+
+Context:
+- Resource samples, trace spans, and existing debug events moved from temporary or in-memory storage into `runtime-data/`.
+- Bundle-only config redaction did not protect secret fields or URL values already persisted inside JSONL records.
+
+What worked:
+- Route every runtime JSONL writer through one size-bounded, recursive-redaction helper.
+- Include the process ID in worker log names and rotate backups with a `.jsonl` suffix so bundle discovery still finds them.
+- Keep recent-sample memory bounded to the API limit and move disk scans plus GPU collection off the request event loop.
+
+Future agents should:
+- Treat retention and record-level redaction as acceptance criteria for any new persistent logging path.
+- Test nested secret keys, URL credentials, query values, rotation, multi-file ordering, and degraded bundle collection.
+- Use router lifespan handlers for new FastAPI startup and shutdown work instead of deprecated event decorators.
+
 ## 2026-07-19 — Article readiness must not wait for enrichment
 
 Context:

--- a/docs/agents/traces/review-logging-pr.md
+++ b/docs/agents/traces/review-logging-pr.md
@@ -1,0 +1,46 @@
+# Logging PR Review Trace
+
+## Goal and done criteria
+
+Review PR #7 for realistic failure modes, repair merge blockers, run the strongest repository checks, and merge only after the branch is clean and verified.
+
+## Status
+
+Verified locally. Merge remains pending until the repaired commit is pushed and GitHub confirms the updated head is mergeable.
+
+## Files changed during review
+
+- `backend/app/core/jsonl.py`
+- `backend/app/core/file_trace_exporter.py`
+- `backend/app/core/logging.py`
+- `backend/app/services/debug_logger.py`
+- `backend/app/services/resource_monitor.py`
+- `backend/app/api/routes/observability.py`
+- `backend/app/middleware/request_tracing.py`
+- `scripts/collect_debug_bundle.py`
+- `frontend/components/observability/browser-telemetry.tsx`
+- Observability tests and documentation
+
+## Commands and tests run
+
+| Command | Result |
+| --- | --- |
+| Focused observability pytest suite | 12 passed |
+| Strict backend mypy | Passed for 149 source files |
+| Frontend TypeScript and ESLint | Passed with one existing TanStack Virtual compiler warning |
+| Router lifespan smoke | Passed |
+| Debug bundle degraded-mode run and ZIP integrity check | Passed |
+| `scripts/self-test` | Passed: 449 backend tests, 3 slow tests deselected |
+
+## Assumptions and risks
+
+- Local debug endpoints remain intentionally unauthenticated because the application and the PR are local-first. Exposing port 8000 publicly would require a separate access-control decision.
+- Runtime redaction targets structured secret keys, URL credentials, query values, and common secret assignments. Arbitrary sensitive prose in an error message cannot be identified with certainty.
+
+## Remaining failures or blockers
+
+- None in the reviewed code. The final GitHub push, PR state change, and merge are still pending.
+
+## Rollback
+
+Revert the review repair commit, then revert PR #7 if the merged observability feature must be removed.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { GeistMono } from 'geist/font/mono'
 import { Instrument_Serif, Outfit } from 'next/font/google'
 import './globals.css'
 import { Providers } from './providers'
+import { BrowserTelemetry } from '@/components/observability/browser-telemetry'
 
 const instrumentSerif = Instrument_Serif({
   weight: '400',
@@ -37,6 +38,7 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         <Providers>
+          <BrowserTelemetry />
           <div className="min-h-screen bg-background text-foreground selection:bg-primary selection:text-primary-foreground">
             {children}
           </div>

--- a/frontend/components/observability/browser-telemetry.tsx
+++ b/frontend/components/observability/browser-telemetry.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react"
 import { API_BASE_URL } from "@/lib/api"
 
-type BrowserEvidence = {
+interface BrowserEvidence {
   timestamp: string
   type: string
   message: string

--- a/frontend/components/observability/browser-telemetry.tsx
+++ b/frontend/components/observability/browser-telemetry.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import { useEffect } from "react"
+import { API_BASE_URL } from "@/lib/api"
+
+type BrowserEvidence = {
+  timestamp: string
+  type: string
+  message: string
+  durationMs?: number
+  source?: string
+  line?: number
+  column?: number
+  stack?: string
+}
+
+const FLUSH_INTERVAL_MS = 5_000
+const MAX_BUFFERED_EVENTS = 50
+const SLOW_TASK_MS = 200
+
+function getSessionId(): string {
+  const key = "thesis_observability_session"
+  const existing = window.sessionStorage.getItem(key)
+  if (existing) return existing
+
+  const value = `browser_${crypto.randomUUID()}`
+  window.sessionStorage.setItem(key, value)
+  return value
+}
+
+function errorDetails(value: unknown): Pick<BrowserEvidence, "message" | "stack"> {
+  if (value instanceof Error) {
+    return { message: value.message, stack: value.stack }
+  }
+  if (typeof value === "string") {
+    return { message: value }
+  }
+  try {
+    return { message: JSON.stringify(value) }
+  } catch {
+    return { message: String(value) }
+  }
+}
+
+export function BrowserTelemetry() {
+  useEffect(() => {
+    const sessionId = getSessionId()
+    let events: BrowserEvidence[] = []
+    let flushing = false
+
+    const enqueue = (event: BrowserEvidence) => {
+      events.push(event)
+      if (events.length > MAX_BUFFERED_EVENTS) {
+        events = events.slice(-MAX_BUFFERED_EVENTS)
+      }
+    }
+
+    const flush = async (preferBeacon = false) => {
+      if (flushing || events.length === 0) return
+      flushing = true
+      const batch = events
+      events = []
+
+      const errors = batch.filter((event) =>
+        ["window_error", "unhandled_rejection", "resource_error"].includes(event.type),
+      )
+      const slowOperations = batch.filter((event) => event.type === "long_task")
+      const payload = {
+        session_id: sessionId,
+        summary: {
+          event_count: batch.length,
+          error_count: errors.length,
+          slow_operation_count: slowOperations.length,
+        },
+        recent_events: batch,
+        slow_operations: slowOperations,
+        errors,
+        dom_stats: {
+          element_count: document.getElementsByTagName("*").length,
+          body_child_count: document.body?.children.length ?? 0,
+        },
+        location: window.location.pathname,
+        user_agent: navigator.userAgent,
+        generated_at: new Date().toISOString(),
+      }
+      const body = JSON.stringify(payload)
+      const endpoint = `${API_BASE_URL}/debug/logs/frontend`
+
+      try {
+        if (
+          preferBeacon &&
+          navigator.sendBeacon(
+            endpoint,
+            new Blob([body], { type: "application/json" }),
+          )
+        ) {
+          return
+        }
+        await fetch(endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+          keepalive: true,
+        })
+      } catch {
+        // Debug telemetry must never create a user-visible failure loop.
+      } finally {
+        flushing = false
+      }
+    }
+
+    const onError = (event: ErrorEvent) => {
+      const details = errorDetails(event.error ?? event.message)
+      enqueue({
+        timestamp: new Date().toISOString(),
+        type: "window_error",
+        message: details.message,
+        stack: details.stack,
+        source: event.filename || undefined,
+        line: event.lineno || undefined,
+        column: event.colno || undefined,
+      })
+    }
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const details = errorDetails(event.reason)
+      enqueue({
+        timestamp: new Date().toISOString(),
+        type: "unhandled_rejection",
+        message: details.message,
+        stack: details.stack,
+      })
+    }
+
+    const onResourceError = (event: Event) => {
+      const target = event.target
+      if (!(target instanceof HTMLElement)) return
+      const source =
+        target.getAttribute("src") ??
+        target.getAttribute("href") ??
+        target.tagName.toLowerCase()
+      enqueue({
+        timestamp: new Date().toISOString(),
+        type: "resource_error",
+        message: `Failed to load ${target.tagName.toLowerCase()}`,
+        source: source.split("?")[0],
+      })
+    }
+
+    window.addEventListener("error", onError)
+    window.addEventListener("unhandledrejection", onUnhandledRejection)
+    window.addEventListener("error", onResourceError, true)
+
+    let observer: PerformanceObserver | null = null
+    if ("PerformanceObserver" in window) {
+      try {
+        observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            if (entry.duration < SLOW_TASK_MS) continue
+            enqueue({
+              timestamp: new Date().toISOString(),
+              type: "long_task",
+              message: entry.name || "Browser main-thread long task",
+              durationMs: Math.round(entry.duration * 10) / 10,
+            })
+          }
+        })
+        observer.observe({ type: "longtask", buffered: true })
+      } catch {
+        observer = null
+      }
+    }
+
+    const navigation = performance.getEntriesByType("navigation")[0]
+    if (navigation instanceof PerformanceNavigationTiming) {
+      enqueue({
+        timestamp: new Date().toISOString(),
+        type: "navigation_timing",
+        message: window.location.pathname,
+        durationMs: Math.round(navigation.duration * 10) / 10,
+      })
+    }
+
+    const interval = window.setInterval(() => void flush(), FLUSH_INTERVAL_MS)
+    const onPageHide = () => void flush(true)
+    window.addEventListener("pagehide", onPageHide)
+
+    return () => {
+      window.clearInterval(interval)
+      window.removeEventListener("error", onError)
+      window.removeEventListener("unhandledrejection", onUnhandledRejection)
+      window.removeEventListener("error", onResourceError, true)
+      window.removeEventListener("pagehide", onPageHide)
+      observer?.disconnect()
+      void flush(true)
+    }
+  }, [])
+
+  return null
+}

--- a/runtime-data/.gitignore
+++ b/runtime-data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/collect-debug-bundle
+++ b/scripts/collect-debug-bundle
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec python3 "$ROOT_DIR/scripts/collect_debug_bundle.py" --root "$ROOT_DIR" "$@"

--- a/scripts/collect_debug_bundle.py
+++ b/scripts/collect_debug_bundle.py
@@ -19,8 +19,16 @@ from pathlib import Path
 from typing import Any
 
 SENSITIVE_KEY = re.compile(
-    r"(key|token|secret|password|cookie|authorization)", re.IGNORECASE
+    r"(?:^|[_-])(?:api[_-]?key|key|token|secret|password|cookie|authorization)"
+    r"(?:$|[_-])",
+    re.IGNORECASE,
 )
+SENSITIVE_ASSIGNMENT = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password|cookie|authorization)\b"
+    r"(\s*[:=]\s*)([^\s,;]+)"
+)
+URL_QUERY_VALUE = re.compile(r"([?&][^=\s&#]+)=([^&#\s]*)")
+URL_PASSWORD = re.compile(r"(\b[a-z][a-z0-9+.-]*://[^:/\s@]+):([^@\s/]+)@", re.I)
 CONFIG_ENV_NAMES = (
     "ENVIRONMENT",
     "DEBUG",
@@ -37,6 +45,8 @@ CONFIG_ENV_NAMES = (
     "THESIS_PERFORMANCE_SAMPLE_SECONDS",
     "THESIS_RUNTIME_DIR",
     "THESIS_SERVICE_NAME",
+    "THESIS_LOG_MAX_BYTES",
+    "THESIS_LOG_BACKUP_COUNT",
     "OTEL_ENABLED",
     "OTEL_SAMPLE_RATE",
     "OTEL_EXPORTER_ENDPOINT",
@@ -80,11 +90,31 @@ def parse_timestamp(value: object) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
+def sanitize_text(value: str) -> str:
+    """Redact common secret forms and URL values embedded in free-form text."""
+    value = URL_PASSWORD.sub(r"\1:<redacted>@", value)
+    value = URL_QUERY_VALUE.sub(r"\1=<redacted>", value)
+    return SENSITIVE_ASSIGNMENT.sub(r"\1\2<redacted>", value)
+
+
 def sanitize_value(key: str, value: object) -> object:
     if key.upper() == "DATABASE_URL" and isinstance(value, str):
-        return re.sub(r"//([^:/]+):([^@]+)@", r"//\1:<redacted>@", value)
+        return URL_PASSWORD.sub(r"\1:<redacted>@", value)
     if SENSITIVE_KEY.search(key):
         return "<redacted>"
+    return sanitize_record(value)
+
+
+def sanitize_record(value: object) -> object:
+    """Recursively redact sensitive fields before evidence leaves runtime data."""
+    if isinstance(value, dict):
+        return {str(key): sanitize_value(str(key), item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [sanitize_record(item) for item in value]
+    if isinstance(value, tuple):
+        return [sanitize_record(item) for item in value]
+    if isinstance(value, str):
+        return sanitize_text(value)
     return value
 
 
@@ -117,7 +147,11 @@ def fetch_json(base_url: str, path: str, timeout: float = 5.0) -> dict[str, obje
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             payload = json.loads(response.read().decode("utf-8"))
-        return {"available": True, "url": url, "payload": payload}
+        return {
+            "available": True,
+            "url": sanitize_text(url),
+            "payload": sanitize_record(payload),
+        }
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
         return {"available": False, "url": url, "error": str(exc)}
 
@@ -148,7 +182,10 @@ def filter_jsonl(source: Path, destination: Path, since: datetime) -> dict[str, 
             timestamp = parse_timestamp(record.get("timestamp"))
             if timestamp is not None and timestamp < since:
                 continue
-            output.write(json.dumps(record, default=str, separators=(",", ":")) + "\n")
+            output.write(
+                json.dumps(sanitize_record(record), default=str, separators=(",", ":"))
+                + "\n"
+            )
             kept += 1
 
     if kept == 0:
@@ -190,7 +227,10 @@ def collect_logs(
 
 def write_json(path: Path, value: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, default=str) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(sanitize_record(value), indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
 
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:

--- a/scripts/collect_debug_bundle.py
+++ b/scripts/collect_debug_bundle.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Collect a compact, agent-readable Thesis debug bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+SENSITIVE_KEY = re.compile(
+    r"(key|token|secret|password|cookie|authorization)", re.IGNORECASE
+)
+CONFIG_ENV_NAMES = (
+    "ENVIRONMENT",
+    "DEBUG",
+    "ENABLE_DATABASE",
+    "ENABLE_VECTOR_STORE",
+    "DATABASE_URL",
+    "CHROMA_HOST",
+    "CHROMA_PORT",
+    "EMBEDDING_SERVICE_URL",
+    "EMBEDDING_MODEL_NAME",
+    "EMBEDDING_BATCH_SIZE",
+    "EMBEDDING_QUEUE_SIZE",
+    "THESIS_OBSERVABILITY_ENABLED",
+    "THESIS_PERFORMANCE_SAMPLE_SECONDS",
+    "THESIS_RUNTIME_DIR",
+    "THESIS_SERVICE_NAME",
+    "OTEL_ENABLED",
+    "OTEL_SAMPLE_RATE",
+    "OTEL_EXPORTER_ENDPOINT",
+)
+API_ENDPOINTS = {
+    "runtime": "/debug/observability/runtime",
+    "resources": "/debug/observability/resources",
+    "performance": "/debug/observability/performance?limit=1000&since_minutes={minutes}",
+    "debug_report": "/debug/logs/report",
+    "profiling": "/profiling/summary",
+    "queries": "/profiling/queries",
+    "pipeline": "/debug/metrics/pipeline",
+    "storage_drift": "/debug/storage/drift",
+    "startup": "/debug/startup",
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def parse_duration(value: str) -> timedelta:
+    match = re.fullmatch(r"\s*(\d+(?:\.\d+)?)\s*([smhd])\s*", value.lower())
+    if not match:
+        raise argparse.ArgumentTypeError("duration must look like 30m, 2h, 1d, or 90s")
+    amount = float(match.group(1))
+    unit = match.group(2)
+    seconds = amount * {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    return timedelta(seconds=seconds)
+
+
+def parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def sanitize_value(key: str, value: object) -> object:
+    if key.upper() == "DATABASE_URL" and isinstance(value, str):
+        return re.sub(r"//([^:/]+):([^@]+)@", r"//\1:<redacted>@", value)
+    if SENSITIVE_KEY.search(key):
+        return "<redacted>"
+    return value
+
+
+def run_command(
+    command: list[str], cwd: Path, timeout: float = 10.0
+) -> dict[str, object]:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"available": False, "error": str(exc), "command": command}
+    return {
+        "available": True,
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout[-100_000:],
+        "stderr": result.stderr[-50_000:],
+    }
+
+
+def fetch_json(base_url: str, path: str, timeout: float = 5.0) -> dict[str, object]:
+    url = f"{base_url.rstrip('/')}{path}"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        return {"available": True, "url": url, "payload": payload}
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        return {"available": False, "url": url, "error": str(exc)}
+
+
+def filter_jsonl(source: Path, destination: Path, since: datetime) -> dict[str, object]:
+    total = 0
+    kept = 0
+    malformed = 0
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        source_handle = source.open(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return {"source": str(source), "available": False, "error": str(exc)}
+
+    with source_handle, destination.open("w", encoding="utf-8") as output:
+        for line in source_handle:
+            if not line.strip():
+                continue
+            total += 1
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            if not isinstance(record, dict):
+                malformed += 1
+                continue
+            timestamp = parse_timestamp(record.get("timestamp"))
+            if timestamp is not None and timestamp < since:
+                continue
+            output.write(json.dumps(record, default=str, separators=(",", ":")) + "\n")
+            kept += 1
+
+    if kept == 0:
+        destination.unlink(missing_ok=True)
+    return {
+        "source": str(source),
+        "destination": str(destination),
+        "available": True,
+        "total_records": total,
+        "kept_records": kept,
+        "malformed_records": malformed,
+    }
+
+
+def collect_logs(
+    root: Path, runtime_dir: Path, bundle_dir: Path, since: datetime
+) -> list[dict[str, object]]:
+    candidates: set[Path] = set()
+    if runtime_dir.exists():
+        candidates.update(
+            path for path in runtime_dir.rglob("*.jsonl") if path.is_file()
+        )
+    legacy_dir = Path(os.environ.get("DEBUG_LOG_DIR", "/tmp/scoop_debug_logs"))
+    if legacy_dir.exists() and legacy_dir.resolve() != runtime_dir.resolve():
+        candidates.update(
+            path for path in legacy_dir.rglob("*.jsonl") if path.is_file()
+        )
+
+    results: list[dict[str, object]] = []
+    for source in sorted(candidates):
+        try:
+            relative = source.relative_to(runtime_dir)
+        except ValueError:
+            relative = Path("legacy") / source.name
+        destination = bundle_dir / "logs" / relative
+        results.append(filter_jsonl(source, destination, since))
+    return results
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, default=str) + "\n", encoding="utf-8")
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    if not path.exists():
+        return records
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(value, dict):
+                    records.append(value)
+    except OSError:
+        return []
+    return records
+
+
+def summarize(bundle_dir: Path, manifest: dict[str, Any]) -> str:
+    records: list[dict[str, Any]] = []
+    for path in (
+        (bundle_dir / "logs").rglob("*.jsonl") if (bundle_dir / "logs").exists() else []
+    ):
+        records.extend(read_jsonl(path))
+
+    errors = [
+        record
+        for record in records
+        if record.get("error")
+        or str(record.get("event_type", "")).endswith("_error")
+        or record.get("result") == "error"
+        or str(record.get("level", "")).lower() in {"error", "critical"}
+    ]
+    slow = [
+        record
+        for record in records
+        if record.get("is_slow")
+        or record.get("kind") == "operation"
+        and (record.get("duration_ms") or 0) >= 1000
+    ]
+    samples = [record for record in records if record.get("kind") == "resource_sample"]
+
+    max_process_cpu = max(
+        (
+            float(record.get("process", {}).get("cpu_percent") or 0)
+            for record in samples
+        ),
+        default=0.0,
+    )
+    max_memory_percent = max(
+        (
+            float(record.get("system", {}).get("memory_used_percent") or 0)
+            for record in samples
+        ),
+        default=0.0,
+    )
+    max_disk_percent = max(
+        (float(record.get("disk", {}).get("used_percent") or 0) for record in samples),
+        default=0.0,
+    )
+    max_event_loop_lag = max(
+        (
+            float(record.get("process", {}).get("event_loop_lag_ms") or 0)
+            for record in samples
+        ),
+        default=0.0,
+    )
+
+    evidence: list[str] = []
+    if errors:
+        evidence.append(f"- {len(errors)} error-bearing event(s) were captured.")
+    if slow:
+        evidence.append(
+            f"- {len(slow)} operation(s) exceeded 1 second or were explicitly flagged slow."
+        )
+    if samples:
+        evidence.extend(
+            [
+                f"- Peak sampled process CPU: {max_process_cpu:.1f}%.",
+                f"- Peak sampled system memory use: {max_memory_percent:.1f}%.",
+                f"- Peak sampled disk use: {max_disk_percent:.1f}%.",
+                f"- Peak sampled event-loop lag: {max_event_loop_lag:.1f} ms.",
+            ]
+        )
+    if not evidence:
+        evidence.append(
+            "- No structured events were available in the selected time window."
+        )
+
+    revision = manifest.get("git", {}).get("revision", {})
+    commit = "unknown"
+    if isinstance(revision, dict):
+        commit = str(revision.get("stdout", "")).strip() or "unknown"
+
+    return "\n".join(
+        [
+            "# Thesis Debug Bundle",
+            "",
+            f"Generated: {manifest['generated_at']}",
+            f"Window start: {manifest['since']}",
+            f"Git revision: `{commit}`",
+            "",
+            "## Evidence summary",
+            "",
+            *evidence,
+            "",
+            "## How to use this bundle",
+            "",
+            "Start with `manifest.json`, then correlate `request_id`, `trace_id`, `service`, "
+            "`operation`, and timestamps across `logs/` and `api/`. Conclusions should cite "
+            "the underlying records rather than this generated summary alone.",
+            "",
+        ]
+    )
+
+
+def build_bundle(args: argparse.Namespace) -> tuple[Path, Path]:
+    root = Path(args.root).resolve()
+    runtime_dir = Path(
+        os.environ.get("THESIS_RUNTIME_DIR", root / "runtime-data")
+    ).resolve()
+    generated_at = utc_now()
+    since = generated_at - args.since
+    stamp = generated_at.strftime("%Y-%m-%dT%H-%M-%SZ")
+    output_root = Path(args.output or root / "debug-bundles").resolve()
+    bundle_dir = output_root / stamp
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    log_results = collect_logs(root, runtime_dir, bundle_dir, since)
+    minutes = max(1, int(args.since.total_seconds() / 60))
+
+    api_results: dict[str, dict[str, object]] = {}
+    for name, path_template in API_ENDPOINTS.items():
+        path = path_template.format(minutes=minutes)
+        result = fetch_json(args.api_url, path, timeout=args.timeout)
+        api_results[name] = result
+        write_json(bundle_dir / "api" / f"{name}.json", result)
+
+    git_results = {
+        "revision": run_command(["git", "rev-parse", "HEAD"], root),
+        "branch": run_command(["git", "branch", "--show-current"], root),
+        "status": run_command(["git", "status", "--short"], root),
+        "recent_commits": run_command(
+            ["git", "log", "-10", "--pretty=format:%H%x09%cI%x09%s"], root
+        ),
+    }
+    write_json(bundle_dir / "git" / "state.json", git_results)
+
+    configuration = {
+        name: sanitize_value(name, os.environ[name])
+        for name in CONFIG_ENV_NAMES
+        if name in os.environ
+    }
+    runtime = {
+        "python": sys.version,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "node": run_command(["node", "--version"], root),
+        "docker_compose": run_command(
+            ["docker", "compose", "ps", "--format", "json"], root, timeout=15
+        ),
+        "configuration": configuration,
+        "disk_usage": {
+            "root": str(root),
+            "total_bytes": shutil.disk_usage(root).total,
+            "used_bytes": shutil.disk_usage(root).used,
+            "free_bytes": shutil.disk_usage(root).free,
+        },
+    }
+    write_json(bundle_dir / "runtime" / "context.json", runtime)
+
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": generated_at.isoformat(),
+        "since": since.isoformat(),
+        "window_seconds": args.since.total_seconds(),
+        "root": str(root),
+        "runtime_dir": str(runtime_dir),
+        "api_url": args.api_url,
+        "logs": log_results,
+        "api": api_results,
+        "git": git_results,
+    }
+    write_json(bundle_dir / "manifest.json", manifest)
+    (bundle_dir / "summary.md").write_text(
+        summarize(bundle_dir, manifest), encoding="utf-8"
+    )
+
+    archive_path = output_root / f"{stamp}.zip"
+    with zipfile.ZipFile(
+        archive_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
+        for path in sorted(bundle_dir.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(bundle_dir.parent))
+    return bundle_dir, archive_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since", type=parse_duration, default=parse_duration("30m"))
+    parser.add_argument("--api-url", default="http://localhost:8000")
+    parser.add_argument("--root", default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--output")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        bundle_dir, archive_path = build_bundle(args)
+    except FileExistsError as exc:
+        print(f"Bundle already exists: {exc}", file=sys.stderr)
+        return 2
+    print(bundle_dir)
+    print(archive_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

Adds a deliberately small, local-first observability layer aimed at evidence-based debugging by coding agents.

- Persists the existing structured debug events under `runtime-data/logs/`.
- Samples backend and embedding-worker CPU, memory, disk, network, threads, file descriptors, event-loop lag, and optional NVIDIA GPU state to JSONL.
- Exports completed OpenTelemetry spans to local JSONL when tracing is enabled, while preserving optional OTLP export.
- Correlates request IDs with trace IDs and avoids persisting query-parameter values.
- Records embedding model-load and batch timings without logging input text.
- Captures browser errors, rejected promises, failed resources, navigation timing, and long main-thread tasks through the existing frontend debug endpoint.
- Adds `/debug/observability/*` resource, runtime, performance, and health endpoints.
- Adds `./scripts/collect-debug-bundle --since 30m`, which creates a sanitized agent-readable directory and ZIP containing logs, traces, resource samples, existing profiling/debug reports, runtime facts, and Git state.
- Documents the workflow and keeps generated evidence out of Git.

## Why

The existing repository already had useful profiling, debug logging, startup timing, storage-drift inspection, and OpenTelemetry hooks, but the evidence was fragmented or ephemeral. This PR connects those pieces into one small durable workflow so an agent can determine what failed, which operation was involved, and whether the pressure came from CPU, memory, disk, GPU, queueing, database work, network calls, or browser execution.

This intentionally does not add Prometheus, Grafana, Loki, Tempo, Pyroscope, or another observability database. Those can be introduced later only if the local evidence fails to answer a real debugging question.

## Validation

- `uvx ruff check backend scripts/collect_debug_bundle.py`
- `uvx ruff format --check backend scripts/collect_debug_bundle.py`
- Focused pytest suite for resource sampling, bundle filtering/redaction, real OpenTelemetry span export, and compatibility with the latest console-logging behavior: **10 passed**
- Python bytecode compilation for all added and modified backend modules
- Frontend TypeScript syntax transpilation for the telemetry component and layout integration
- YAML parse validation for `docker-compose.yml`
- Ran the bundle collector with the backend and Docker unavailable; it still produced a valid directory and ZIP with explicit unavailable-source records
- Rebased the final single commit onto current `main` and retained the newer Intelligence Atlas route and console-summary logging behavior

## Known validation limit

The current execution environment did not have a Docker CLI, so `docker compose config` and a live multi-container smoke test could not be run here. The Compose file was parsed as valid YAML, and the collector's degraded-mode behavior was exercised.

GitHub currently reports no Actions workflow runs or commit status checks for the PR head.