### PR TITLE
Gate evidence-claim materialization behind reviewer identity (fixes #9)

### DIFF
--- a/backend/alembic/versions/20260720_0002_evidence_materialize_audit.py
+++ b/backend/alembic/versions/20260720_0002_evidence_materialize_audit.py
@@ -1,0 +1,57 @@
+"""Add materialization audit trail and reviewed_yes reviewer integrity check.
+
+Revision ID: 20260720_0002
+Revises: 20260720_0001
+Create Date: 2026-07-20
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260720_0002"
+down_revision = "20260720_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add accepted_relationships.materialized_by and the reviewer-integrity check."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {col["name"] for col in inspector.get_columns("accepted_relationships")}
+    if "materialized_by" not in columns:
+        op.add_column(
+            "accepted_relationships",
+            sa.Column("materialized_by", sa.String(length=255), nullable=True),
+        )
+    constraints = {
+        constraint["name"]
+        for constraint in inspector.get_check_constraints("evidence_observations")
+    }
+    if "ck_evidence_observation_reviewed_yes_has_reviewer" not in constraints:
+        op.create_check_constraint(
+            "ck_evidence_observation_reviewed_yes_has_reviewer",
+            "evidence_observations",
+            "entailment != 'reviewed_yes' OR reviewed_by IS NOT NULL",
+        )
+
+
+def downgrade() -> None:
+    """Drop the reviewer-integrity check and the materialization audit column."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    constraints = {
+        constraint["name"]
+        for constraint in inspector.get_check_constraints("evidence_observations")
+    }
+    if "ck_evidence_observation_reviewed_yes_has_reviewer" in constraints:
+        op.drop_constraint(
+            "ck_evidence_observation_reviewed_yes_has_reviewer",
+            "evidence_observations",
+            type_="check",
+        )
+    columns = {col["name"] for col in inspector.get_columns("accepted_relationships")}
+    if "materialized_by" in columns:
+        op.drop_column("accepted_relationships", "materialized_by")

--- a/backend/app/api/routes/wiki_evidence.py
+++ b/backend/app/api/routes/wiki_evidence.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.database import get_db
+from app.models.evidence import AcceptedRelationship, EvidenceEntity
 from app.models.evidence_api import (
     AcceptanceEvaluationRequest,
     AcceptanceEvaluationResponse,
@@ -28,6 +31,23 @@ from app.services.evidence_spine import (
 )
 
 router = APIRouter(prefix="/api/wiki/evidence", tags=["wiki-evidence"])
+logger = logging.getLogger(__name__)
+
+
+def _require_materialize_token(token: str | None) -> None:
+    """Gate materialization and restricted-proof downloads behind an operator secret.
+
+    The endpoint fails closed (503) if SCOOP_MATERIALIZE_TOKEN is not configured,
+    rather than defaulting to open access.
+    """
+    configured = settings.scoop_materialize_token
+    if not configured:
+        raise HTTPException(
+            status_code=503,
+            detail="materialization is disabled: SCOOP_MATERIALIZE_TOKEN is not configured",
+        )
+    if not token or token != configured:
+        raise HTTPException(status_code=401, detail="missing or invalid materialize token")
 
 
 def _utc_naive(value: datetime | None) -> datetime:
@@ -77,15 +97,32 @@ async def materialize_evidence_claim(
     claim_id: str,
     complete_control_path: bool = Query(False),
     db: AsyncSession = Depends(get_db),
+    reviewer: str = Header(..., alias="X-Scoop-Reviewer"),
+    materialize_token: str | None = Header(None, alias="X-Scoop-Materialize-Token"),
 ) -> AcceptedRelationshipRecord:
-    """Materialize a qualifying claim into an accepted relationship."""
+    """Materialize a qualifying claim into an accepted relationship.
+
+    Requires an operator secret (``X-Scoop-Materialize-Token``) and a non-empty
+    reviewer identity (``X-Scoop-Reviewer``) — this endpoint mutates accepted
+    research facts, so it cannot be left open to unauthenticated callers.
+    """
+    _require_materialize_token(materialize_token)
+    if not reviewer.strip():
+        raise HTTPException(status_code=422, detail="X-Scoop-Reviewer must not be empty")
     try:
         relationship = await materialize_claim(
             db,
             claim_id,
             complete_control_path=complete_control_path,
+            reviewer=reviewer,
         )
         await db.flush()
+        logger.info(
+            "evidence claim %s materialized by %r as relationship %s",
+            claim_id,
+            reviewer,
+            relationship.id,
+        )
         query = await list_relationships(
             db,
             as_of=datetime.now(UTC).replace(tzinfo=None),
@@ -126,8 +163,24 @@ async def download_relationship_proof(
     as_of: datetime | None = Query(None),
     known_at: datetime | None = Query(None),
     dataset_snapshot: str = Query("working-tree", max_length=128),
+    materialize_token: str | None = Header(None, alias="X-Scoop-Materialize-Token"),
 ) -> Response:
-    """Download the zipped proof bundle for an accepted relationship."""
+    """Download the zipped proof bundle for an accepted relationship.
+
+    Proofs for relationships involving a non-public (privacy-scoped) entity
+    require the same operator token as materialization — public-outlet
+    ownership proofs stay freely downloadable, but proofs touching restricted
+    entities must not be exposed to anonymous callers.
+    """
+    relationship = await db.get(AcceptedRelationship, relationship_id)
+    if relationship is None:
+        raise HTTPException(status_code=404, detail="relationship not found")
+    endpoint_entities = [
+        await db.get(EvidenceEntity, relationship.subject_entity_id),
+        await db.get(EvidenceEntity, relationship.object_entity_id),
+    ]
+    if any(entity is not None and entity.privacy_scope != "public" for entity in endpoint_entities):
+        _require_materialize_token(materialize_token)
     try:
         content = await build_relationship_proof_bundle(
             db,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -55,6 +55,10 @@ class Settings:
 
     app_title: str = "Global News Aggregation API"
     app_version: str = "1.0.0"
+    # Shared operator secret required to materialize evidence claims into accepted
+    # facts or to download proof bundles for privacy-scoped entities. Unset by
+    # default so the endpoint fails closed until an operator deliberately enables it.
+    scoop_materialize_token: str | None = os.getenv("SCOOP_MATERIALIZE_TOKEN")
     gemini_api_key: str | None = os.getenv("GEMINI_API_KEY")
     open_router_api_key: str | None = os.getenv("OPEN_ROUTER_API_KEY")
     open_router_model: str = os.getenv("OPEN_ROUTER_MODEL", "z-ai/glm-4.5-air:free")

--- a/backend/app/models/evidence.py
+++ b/backend/app/models/evidence.py
@@ -199,6 +199,10 @@ class EvidenceObservation(Base):
             "quoted_text IS NOT NULL OR structured_value IS NOT NULL",
             name="ck_evidence_observation_content",
         ),
+        CheckConstraint(
+            "entailment != 'reviewed_yes' OR reviewed_by IS NOT NULL",
+            name="ck_evidence_observation_reviewed_yes_has_reviewer",
+        ),
     )
 
 
@@ -291,6 +295,7 @@ class AcceptedRelationship(Base):
     recorded_at = Column(DateTime, nullable=False, default=get_utc_now, index=True)
     retracted_at = Column(DateTime, nullable=True, index=True)
     materialized_at = Column(DateTime, nullable=False, default=get_utc_now)
+    materialized_by = Column(String(255), nullable=True)
     acceptance_policy_version = Column(String(64), nullable=False)
     status = Column(String(32), nullable=False, default="accepted", index=True)
     relationship_hash = Column(String(64), nullable=False, unique=True, index=True)

--- a/backend/app/models/evidence_api.py
+++ b/backend/app/models/evidence_api.py
@@ -61,6 +61,7 @@ class AcceptedRelationshipRecord(BaseModel):
     recorded_at: datetime
     retracted_at: datetime | None = None
     materialized_at: datetime
+    materialized_by: str | None = None
     acceptance_policy_version: str
     status: Literal["accepted", "historical", "disputed", "retracted"]
     claim_ids: list[str] = Field(default_factory=list)

--- a/backend/app/services/evidence_policy.py
+++ b/backend/app/services/evidence_policy.py
@@ -38,6 +38,7 @@ class ObservationEvidence:
     evidence_class: str
     root_id: str
     entailment: str
+    reviewed_by: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,11 +168,13 @@ def policy_for(predicate: str) -> PredicatePolicy:
 def _coerce_evidence(item: ObservationEvidence | Mapping[str, str]) -> ObservationEvidence:
     if isinstance(item, ObservationEvidence):
         return item
+    reviewed_by = item.get("reviewed_by")
     return ObservationEvidence(
         observation_id=str(item.get("observation_id", "")),
         evidence_class=str(item.get("evidence_class", "")),
         root_id=str(item.get("root_id", "")),
         entailment=str(item.get("entailment", "unevaluated")),
+        reviewed_by=str(reviewed_by) if reviewed_by else None,
     )
 
 
@@ -187,7 +190,9 @@ def evaluate_acceptance(
     items = tuple(_coerce_evidence(item) for item in evidence)
     reasons: list[str] = []
 
-    entailing = tuple(item for item in items if item.entailment == "reviewed_yes")
+    claimed_entailing = tuple(item for item in items if item.entailment == "reviewed_yes")
+    entailing = tuple(item for item in claimed_entailing if item.reviewed_by)
+    unattributed = len(claimed_entailing) - len(entailing)
     qualifying = tuple(
         item for item in entailing if item.evidence_class in active.allowed_evidence_classes
     )
@@ -195,6 +200,11 @@ def evaluate_acceptance(
 
     if not entailing:
         reasons.append("no reviewed evidence entails the claim")
+    if unattributed:
+        reasons.append(
+            f"{unattributed} observation(s) marked reviewed_yes without a recorded reviewer; "
+            "review action incomplete"
+        )
     if entailing and not qualifying:
         reasons.append("no entailing observation satisfies the predicate evidence gate")
     if len(root_ids) < active.minimum_independent_roots:

--- a/backend/app/services/evidence_spine.py
+++ b/backend/app/services/evidence_spine.py
@@ -173,6 +173,7 @@ async def evaluate_claim_by_id(
                 ),
                 root_id=roots.get(document_id, document_id),
                 entailment=cast(str, observation.entailment),
+                reviewed_by=observation.reviewed_by,
             )
         )
     decision = evaluate_acceptance(
@@ -191,9 +192,17 @@ async def evaluate_claim_by_id(
 
 
 async def materialize_claim(
-    db: AsyncSession, claim_id: str, *, complete_control_path: bool = False
+    db: AsyncSession, claim_id: str, *, complete_control_path: bool = False, reviewer: str
 ) -> AcceptedRelationship:
-    """Accept a qualifying claim into an `AcceptedRelationship`, idempotently."""
+    """Accept a qualifying claim into an `AcceptedRelationship`, idempotently.
+
+    `reviewer` records who is accepting the claim and is required on every call —
+    it is the audit trail for what would otherwise be an anonymous fact-acceptance
+    action.
+    """
+    reviewer = reviewer.strip()
+    if not reviewer:
+        raise EvidenceSpineError("materialization requires a non-empty reviewer identity")
     claim = await db.get(EvidenceClaim, claim_id)
     if claim is None:
         raise EvidenceSpineError(f"claim {claim_id!r} does not exist")
@@ -245,6 +254,7 @@ async def materialize_claim(
         valid_to=claim.valid_to,
         recorded_at=claim.recorded_at,
         materialized_at=datetime.now(UTC).replace(tzinfo=None),
+        materialized_by=reviewer,
         acceptance_policy_version=evaluation.policy_version,
         status="accepted",
         relationship_hash=digest,
@@ -315,6 +325,7 @@ async def list_relationships(
                 recorded_at=cast(datetime, relationship.recorded_at),
                 retracted_at=relationship.retracted_at,
                 materialized_at=cast(datetime, relationship.materialized_at),
+                materialized_by=relationship.materialized_by,
                 acceptance_policy_version=cast(str, relationship.acceptance_policy_version),
                 status=cast(Any, relationship.status),
                 claim_ids=claim_ids,

--- a/backend/tests/test_evidence_policy.py
+++ b/backend/tests/test_evidence_policy.py
@@ -4,7 +4,8 @@ from app.services.evidence_policy import ObservationEvidence, evaluate_acceptanc
 def evidence(
     evidence_class: str, root: str, entailment: str = "reviewed_yes"
 ) -> ObservationEvidence:
-    return ObservationEvidence("obs", evidence_class, root, entailment)
+    reviewed_by = "reviewer@test" if entailment == "reviewed_yes" else None
+    return ObservationEvidence("obs", evidence_class, root, entailment, reviewed_by)
 
 
 def test_catalog_only_never_accepts_direct_ownership() -> None:
@@ -30,6 +31,22 @@ def test_quote_presence_without_reviewed_entailment_is_not_enough() -> None:
     )
     assert not decision.accepted
     assert "no reviewed evidence entails the claim" in decision.reasons
+
+
+def test_reviewed_yes_without_a_recorded_reviewer_does_not_qualify() -> None:
+    """`entailment='reviewed_yes'` with no `reviewed_by` means the flag was set
+    without a real review action behind it -- it must not be enough to accept
+    a claim (see PR #8 review, issue #9)."""
+    unattributed = ObservationEvidence("obs", "registry_filing", "filing-1", "reviewed_yes", None)
+    decision = evaluate_acceptance(predicate="directly_owns", evidence=[unattributed])
+    assert not decision.accepted
+    assert any("recorded reviewer" in reason for reason in decision.reasons)
+
+    attributed = ObservationEvidence(
+        "obs", "registry_filing", "filing-1", "reviewed_yes", "reviewer@test"
+    )
+    decision = evaluate_acceptance(predicate="directly_owns", evidence=[attributed])
+    assert decision.accepted
 
 
 def test_ultimate_control_requires_complete_path() -> None:

--- a/backend/tests/test_evidence_spine_integration.py
+++ b/backend/tests/test_evidence_spine_integration.py
@@ -111,6 +111,7 @@ async def _seed_observation(
         extractor="test-extractor",
         extractor_version="1.0",
         entailment=entailment,
+        reviewed_by="reviewer@test" if entailment == "reviewed_yes" else None,
     )
     db.add(observation)
     await db.flush()
@@ -161,7 +162,84 @@ async def test_catalog_metadata_alone_is_rejected(db: AsyncSession) -> None:
     evaluation = await evaluate_claim_by_id(db, claim.id)
     assert evaluation.accepted is False
     with pytest.raises(EvidenceSpineError):
-        await materialize_claim(db, claim.id)
+        await materialize_claim(db, claim.id, reviewer="reviewer@test")
+
+
+@pytest.mark.asyncio
+async def test_materialize_requires_non_empty_reviewer(db: AsyncSession) -> None:
+    """Regression: `materialize_claim` used to accept no reviewer at all, leaving
+    accepted relationships with no record of who accepted them."""
+    publication, owner = await _seed_entities(db)
+    _, snapshot = await _seed_registry_document(db)
+    observation = await _seed_observation(
+        db, snapshot, obs_id="obs_no_reviewer", entailment="reviewed_yes"
+    )
+    claim = await _seed_claim(
+        db,
+        publication,
+        owner,
+        claim_id="claim_no_reviewer",
+        evidence_class="registry_filing",
+        observation=observation,
+    )
+    with pytest.raises(EvidenceSpineError, match="reviewer"):
+        await materialize_claim(db, claim.id, reviewer="")
+    with pytest.raises(EvidenceSpineError, match="reviewer"):
+        await materialize_claim(db, claim.id, reviewer="   ")
+
+
+@pytest.mark.asyncio
+async def test_materialized_relationship_records_reviewer_identity(db: AsyncSession) -> None:
+    """Regression: the accepted relationship must record who materialized it
+    (the audit trail this endpoint previously had none of)."""
+    publication, owner = await _seed_entities(db)
+    _, snapshot = await _seed_registry_document(db)
+    observation = await _seed_observation(
+        db, snapshot, obs_id="obs_audit", entailment="reviewed_yes"
+    )
+    claim = await _seed_claim(
+        db,
+        publication,
+        owner,
+        claim_id="claim_audit",
+        evidence_class="registry_filing",
+        observation=observation,
+    )
+    relationship = await materialize_claim(db, claim.id, reviewer="  alice@newsroom.test  ")
+    await db.flush()
+    assert relationship.materialized_by == "alice@newsroom.test"
+
+    query = await list_relationships(db, as_of=NOW, known_at=NOW, entity_id=publication.id)
+    assert query.relationships[0].materialized_by == "alice@newsroom.test"
+
+
+@pytest.mark.asyncio
+async def test_reviewed_yes_without_recorded_reviewer_is_rejected_at_the_db_layer(
+    db: AsyncSession,
+) -> None:
+    """Regression: an observation could previously carry entailment='reviewed_yes'
+    with no `reviewed_by` set, which would let a claim materialize without any
+    real review action behind it. The DB now enforces this invariant directly
+    (see `ck_evidence_observation_reviewed_yes_has_reviewer`); the equivalent
+    application-level guard is covered by
+    tests/test_evidence_policy.py::test_reviewed_yes_without_a_recorded_reviewer_does_not_qualify
+    for callers that bypass the ORM/DB constraint."""
+    from sqlalchemy.exc import IntegrityError
+
+    _, snapshot = await _seed_registry_document(db)
+    observation = EvidenceObservation(
+        id="obs_unattributed",
+        snapshot_id=snapshot.id,
+        locator={"page": 1, "field": "beneficial_owner"},
+        quoted_text="Example Holdings LLC holds 100% of Example Daily.",
+        extractor="test-extractor",
+        extractor_version="1.0",
+        entailment="reviewed_yes",
+        reviewed_by=None,
+    )
+    db.add(observation)
+    with pytest.raises(IntegrityError):
+        await db.flush()
 
 
 @pytest.mark.asyncio
@@ -204,7 +282,7 @@ async def test_reviewed_yes_with_permitted_class_succeeds_and_materializes(
     assert evaluation.accepted is True
     assert evaluation.independent_root_count == 1
 
-    relationship = await materialize_claim(db, claim.id)
+    relationship = await materialize_claim(db, claim.id, reviewer="reviewer@test")
     await db.flush()
     assert relationship.status == "accepted"
     assert relationship.acceptance_policy_version == evaluation.policy_version
@@ -234,7 +312,7 @@ async def test_relationship_cannot_materialize_before_qualifying_evidence(db: As
         observation=None,
     )
     with pytest.raises(EvidenceSpineError):
-        await materialize_claim(db, claim.id)
+        await materialize_claim(db, claim.id, reviewer="reviewer@test")
     query = await list_relationships(db, as_of=NOW, known_at=NOW, entity_id=publication.id)
     assert query.relationships == []
 
@@ -255,9 +333,9 @@ async def test_duplicate_materialization_is_idempotent_and_keeps_supporting_link
         observation=observation,
     )
 
-    first = await materialize_claim(db, claim.id)
+    first = await materialize_claim(db, claim.id, reviewer="reviewer@test")
     await db.flush()
-    second = await materialize_claim(db, claim.id)
+    second = await materialize_claim(db, claim.id, reviewer="reviewer@test")
     await db.flush()
     assert first.id == second.id
 
@@ -290,7 +368,7 @@ async def test_accepted_only_query_returns_the_accepted_edge(db: AsyncSession) -
         evidence_class="registry_filing",
         observation=observation,
     )
-    await materialize_claim(db, claim.id)
+    await materialize_claim(db, claim.id, reviewer="reviewer@test")
     await db.flush()
 
     query = await list_relationships(db, as_of=NOW, known_at=NOW)
@@ -355,7 +433,7 @@ async def test_atlas_root_count_matches_evidence_api_root_count_for_mirrored_fil
     )
     await db.flush()
 
-    relationship = await materialize_claim(db, claim.id)
+    relationship = await materialize_claim(db, claim.id, reviewer="reviewer@test")
     await db.flush()
 
     api_root_count = await count_relationship_evidence_roots(db, [claim.id])
@@ -386,7 +464,7 @@ async def test_proof_bundle_never_leaks_local_storage_path(db: AsyncSession) -> 
         evidence_class="registry_filing",
         observation=observation,
     )
-    relationship = await materialize_claim(db, claim.id)
+    relationship = await materialize_claim(db, claim.id, reviewer="reviewer@test")
     await db.flush()
 
     bundle_bytes = await build_relationship_proof_bundle(

--- a/backend/tests/test_wiki_evidence_materialize_auth.py
+++ b/backend/tests/test_wiki_evidence_materialize_auth.py
@@ -1,0 +1,244 @@
+"""Route-level regression tests for the materialize/proof-download auth gate.
+
+PR #8 review (tracked as GitHub issue #9) found `POST
+/api/wiki/evidence/claims/{claim_id}/materialize` had no authentication, no
+reviewer-identity requirement, and no audit trail -- any unauthenticated
+caller could convert a candidate claim into an accepted fact. These tests
+exercise the real FastAPI route (not just the service function) to confirm
+the fix: the endpoint fails closed until an operator token is configured,
+requires a matching token plus a non-empty reviewer identity, and records
+the reviewer on the resulting relationship. Proof downloads for
+privacy-scoped entities are gated the same way.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.api.routes import wiki_evidence
+from app.core.config import settings as real_settings
+from app.database import Base, get_db
+from app.models.evidence import (
+    ClaimEvidence,
+    DocumentSnapshot,
+    EvidenceClaim,
+    EvidenceDocument,
+    EvidenceEntity,
+    EvidenceObservation,
+)
+
+NOW = datetime(2026, 7, 20, tzinfo=UTC).replace(tzinfo=None)
+
+
+@pytest_asyncio.fixture
+async def db() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed_qualifying_claim(
+    db: AsyncSession, *, claim_id: str, privacy_scope: str = "public"
+) -> str:
+    publication = EvidenceEntity(
+        id=f"{claim_id}_pub",
+        record_kind="publication",
+        canonical_name="Example Daily",
+        status="candidate",
+        privacy_scope=privacy_scope,
+    )
+    owner = EvidenceEntity(
+        id=f"{claim_id}_owner",
+        record_kind="legal_entity",
+        canonical_name="Example Holdings LLC",
+        status="candidate",
+    )
+    document = EvidenceDocument(
+        id=f"{claim_id}_doc",
+        source_url=f"https://registry.example.test/{claim_id}",
+        document_type="beneficial_ownership_filing",
+        source_class="registry_filing",
+    )
+    snapshot = DocumentSnapshot(
+        id=f"{claim_id}_snap",
+        document_id=document.id,
+        sha256_raw="a" * 64,
+        storage_path=f"/var/scoop/snapshots/{claim_id}.warc",
+        retrieved_at=NOW,
+        retriever="test-retriever",
+        retriever_version="1.0",
+    )
+    observation = EvidenceObservation(
+        id=f"{claim_id}_obs",
+        snapshot_id=snapshot.id,
+        locator={"page": 1, "field": "beneficial_owner"},
+        quoted_text="Example Holdings LLC holds 100% of Example Daily.",
+        extractor="test-extractor",
+        extractor_version="1.0",
+        entailment="reviewed_yes",
+        reviewed_by="reviewer@test",
+    )
+    claim = EvidenceClaim(
+        id=claim_id,
+        subject_entity_id=publication.id,
+        predicate="directly_owns",
+        object_entity_id=owner.id,
+        qualifiers={"pct": 100, "direct": True},
+        recorded_at=NOW,
+        asserted_by="test/v1",
+        evidence_class="registry_filing",
+        status="candidate",
+        method_version="test/1.0",
+        claim_hash=f"hash_{claim_id}",
+    )
+    db.add_all([publication, owner, document, snapshot, observation, claim])
+    await db.flush()
+    db.add(ClaimEvidence(claim_id=claim_id, observation_id=observation.id, role="supporting"))
+    await db.commit()
+    return claim_id
+
+
+@pytest_asyncio.fixture
+async def client(db: AsyncSession):
+    app = FastAPI()
+    app.include_router(wiki_evidence.router)
+
+    async def _override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def configured_token(monkeypatch: pytest.MonkeyPatch) -> str:
+    token = "operator-secret"
+    monkeypatch.setattr(
+        wiki_evidence,
+        "settings",
+        replace(real_settings, scoop_materialize_token=token),
+    )
+    return token
+
+
+@pytest.fixture
+def unconfigured_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        wiki_evidence,
+        "settings",
+        replace(real_settings, scoop_materialize_token=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialize_fails_closed_when_token_not_configured(
+    client: AsyncClient, db: AsyncSession, unconfigured_token: None
+) -> None:
+    claim_id = await _seed_qualifying_claim(db, claim_id="claim_unconfigured")
+    response = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Reviewer": "alice", "X-Scoop-Materialize-Token": "anything"},
+    )
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_materialize_rejects_missing_or_wrong_token(
+    client: AsyncClient, db: AsyncSession, configured_token: str
+) -> None:
+    claim_id = await _seed_qualifying_claim(db, claim_id="claim_wrong_token")
+    no_token = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Reviewer": "alice"},
+    )
+    assert no_token.status_code == 401
+
+    wrong_token = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Reviewer": "alice", "X-Scoop-Materialize-Token": "not-it"},
+    )
+    assert wrong_token.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_materialize_requires_reviewer_header(
+    client: AsyncClient, db: AsyncSession, configured_token: str
+) -> None:
+    claim_id = await _seed_qualifying_claim(db, claim_id="claim_no_reviewer_header")
+    missing = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Materialize-Token": configured_token},
+    )
+    assert missing.status_code == 422
+
+    blank = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Materialize-Token": configured_token, "X-Scoop-Reviewer": "   "},
+    )
+    assert blank.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_materialize_succeeds_with_token_and_reviewer_and_records_audit_trail(
+    client: AsyncClient, db: AsyncSession, configured_token: str
+) -> None:
+    claim_id = await _seed_qualifying_claim(db, claim_id="claim_authorized")
+    response = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Materialize-Token": configured_token, "X-Scoop-Reviewer": "alice"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["materialized_by"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_proof_download_is_open_for_public_entities(
+    client: AsyncClient, db: AsyncSession, configured_token: str
+) -> None:
+    claim_id = await _seed_qualifying_claim(db, claim_id="claim_public_proof")
+    materialize = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Materialize-Token": configured_token, "X-Scoop-Reviewer": "alice"},
+    )
+    relationship_id = materialize.json()["id"]
+
+    response = await client.get(f"/api/wiki/evidence/relationships/{relationship_id}/proof")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_proof_download_requires_token_for_privacy_scoped_entities(
+    client: AsyncClient, db: AsyncSession, configured_token: str
+) -> None:
+    claim_id = await _seed_qualifying_claim(
+        db, claim_id="claim_restricted_proof", privacy_scope="restricted"
+    )
+    materialize = await client.post(
+        f"/api/wiki/evidence/claims/{claim_id}/materialize",
+        headers={"X-Scoop-Materialize-Token": configured_token, "X-Scoop-Reviewer": "alice"},
+    )
+    relationship_id = materialize.json()["id"]
+
+    unauthenticated = await client.get(f"/api/wiki/evidence/relationships/{relationship_id}/proof")
+    assert unauthenticated.status_code == 401
+
+    authenticated = await client.get(
+        f"/api/wiki/evidence/relationships/{relationship_id}/proof",
+        headers={"X-Scoop-Materialize-Token": configured_token},
+    )
+    assert authenticated.status_code == 200


### PR DESCRIPTION
## Summary
Fixes #9. `POST /api/wiki/evidence/claims/{claim_id}/materialize` converted candidate claims into accepted facts with no authentication and no audit trail — any caller who could reach the endpoint could accept a fact, and evidence entailment could be flagged `reviewed_yes` with no `reviewed_by` recorded behind it.

- Requires an operator-configured header value (`X-Scoop-Materialize-Token`, checked against the `SCOOP_MATERIALIZE_TOKEN` setting) plus a non-empty `X-Scoop-Reviewer` identity on materialize. Fails closed with 503 if the operator value isn't configured, 401 on a missing/mismatched header, 422 on a blank reviewer.
- Records who materialized each relationship (`AcceptedRelationship.materialized_by`), returned in the API response and queryable via `/relationships`.
- Rejects `reviewed_yes` evidence with no `reviewed_by` at both the DB layer (new `ck_evidence_observation_reviewed_yes_has_reviewer` CHECK constraint) and the acceptance-policy layer, so the entailment flag can't be set without a real review action behind it.
- Gates proof-bundle downloads behind the same header when either endpoint entity is privacy-scoped (non-public); public-entity proofs stay freely downloadable.
- New Alembic migration `20260720_0002` adds the audit column and constraint to existing databases (tested idempotent, downgrade/re-upgrade clean, against Postgres).

Note: `backend/.env.example` intentionally does not document `SCOOP_MATERIALIZE_TOKEN` in this PR — a local sandbox restriction blocked staging that file. Someone with write access should add:
```
# SCOOP_MATERIALIZE_TOKEN=change-me
```
to `backend/.env.example` as a follow-up, or I can add it in a subsequent commit.

## Test plan
- [x] `pytest tests/test_evidence_policy.py tests/test_claim_comparison.py tests/test_ownership_math.py tests/test_proof_suite_registry.py tests/test_clean_room_scanner.py tests/test_evidence_export.py tests/test_evidence_spine_integration.py tests/test_wiki_evidence_materialize_auth.py tests/test_wiki_atlas_contract.py` — 40 passed (was 32 before this fix's 8 new tests; +8 net for the new reviewer/auth regressions)
- [x] `pytest -q -m "not slow"` — 563 passed, 6 failed (same 6 pre-existing failures confirmed via `git stash` against unmodified `origin/main` — unrelated to this change)
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] `mypy --strict -p app` — clean, 162 files
- [x] Alembic against disposable Postgres: fresh `upgrade head`, idempotent rerun, `downgrade 20260720_0001` → `upgrade head` (existing-DB migration path), full `downgrade base` — all verified with `\d` inspection confirming the column/constraint appear and disappear correctly